### PR TITLE
Migrate storage uploads to imgbb and fix JSX typing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,16 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
+        hostname: "i.ibb.co",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "ibb.co",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
         hostname: "storage.googleapis.com",
         pathname: "/**",
       },

--- a/src/app/api/uploads/machine-image/route.ts
+++ b/src/app/api/uploads/machine-image/route.ts
@@ -1,28 +1,45 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdminFromRequest } from "@/lib/guards";
-import { adminStorage } from "@/lib/firebase-admin";
+import { uploadToImgbbFromDataUrl } from "@/lib/imgbb";
 import { randomUUID } from "crypto";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function resolveExtension(file: File | (Blob & { name?: string })) {
-  if ("name" in file && file.name) {
-    const parts = file.name.split(".");
-    if (parts.length > 1) {
-      return parts.pop()!.toLowerCase();
-    }
-  }
-  if (file.type) {
-    const typeParts = file.type.split("/");
-    if (typeParts.length > 1) return typeParts[1];
-  }
-  return "bin";
-}
-
 function extractMessage(err: unknown, fallback: string) {
   if (err instanceof Error && err.message) return err.message;
   return fallback;
+}
+
+function sanitizeSegment(segment: string) {
+  return segment
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function buildUploadName(nameFromForm?: string | null, fileName?: string) {
+  const base = nameFromForm?.trim() || fileName?.split(".")[0] || "machine";
+  const sanitized = sanitizeSegment(base) || "machine";
+  const suffix = randomUUID();
+  return `${sanitized}-${suffix}`.slice(0, 100);
+}
+
+async function fileToDataUrl(file: File) {
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const mime = file.type || "application/octet-stream";
+  const base64 = buffer.toString("base64");
+  return `data:${mime};base64,${base64}`;
+}
+
+function ensureDataUrl(value: string | null | undefined) {
+  const trimmed = (value ?? "").trim();
+  if (!/^data:[^;]+;base64,/i.test(trimmed)) {
+    throw new Error("INVALID_DATA_URL");
+  }
+  return trimmed;
 }
 
 export async function POST(req: NextRequest) {
@@ -33,28 +50,27 @@ export async function POST(req: NextRequest) {
 
   try {
     const form = await req.formData();
-    const file = form.get("file");
-    if (!file || typeof file === "string") {
+    const entry = form.get("file") ?? form.get("dataUrl");
+    if (!entry) {
       return NextResponse.json({ error: "Arquivo invalido" }, { status: 400 });
     }
 
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const ext = resolveExtension(file);
-    const filename = `public/machines/${randomUUID()}.${ext}`;
-    const bucket = adminStorage.bucket();
-    const storageFile = bucket.file(filename);
+    let dataUrl: string;
+    let fileName: string | undefined;
+    if (typeof entry === "string") {
+      try {
+        dataUrl = ensureDataUrl(entry);
+      } catch {
+        return NextResponse.json({ error: "DATA_URL_INVALIDA" }, { status: 400 });
+      }
+    } else {
+      dataUrl = await fileToDataUrl(entry);
+      fileName = entry.name;
+    }
 
-    await storageFile.save(buffer, {
-      resumable: false,
-      contentType: file.type || "application/octet-stream",
-    });
-    await storageFile.makePublic();
-    await storageFile.setMetadata({
-      contentType: file.type || "application/octet-stream",
-      cacheControl: "public, max-age=31536000",
-    });
-
-    const url = `https://storage.googleapis.com/${bucket.name}/${filename}`;
+    const formName = form.get("name");
+    const uploadName = buildUploadName(typeof formName === "string" ? formName : undefined, fileName);
+    const { url } = await uploadToImgbbFromDataUrl(dataUrl, uploadName);
     return NextResponse.json({ url });
   } catch (err: unknown) {
     return NextResponse.json(

--- a/src/app/api/uploads/template-item-image/route.ts
+++ b/src/app/api/uploads/template-item-image/route.ts
@@ -1,28 +1,45 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdminFromRequest } from "@/lib/guards";
-import { adminStorage } from "@/lib/firebase-admin";
+import { uploadToImgbbFromDataUrl } from "@/lib/imgbb";
 import { randomUUID } from "crypto";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-function resolveExtension(file: File | (Blob & { name?: string })) {
-  if ("name" in file && file.name) {
-    const parts = file.name.split(".");
-    if (parts.length > 1) {
-      return parts.pop()!.toLowerCase();
-    }
-  }
-  if (file.type) {
-    const typeParts = file.type.split("/");
-    if (typeParts.length > 1) return typeParts[1];
-  }
-  return "bin";
-}
-
 function extractMessage(err: unknown, fallback: string) {
   if (err instanceof Error && err.message) return err.message;
   return fallback;
+}
+
+function sanitizeSegment(segment: string) {
+  return segment
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60);
+}
+
+function buildUploadName(nameFromForm?: string | null, fileName?: string) {
+  const base = nameFromForm?.trim() || fileName?.split(".")[0] || "template-item";
+  const sanitized = sanitizeSegment(base) || "template-item";
+  const suffix = randomUUID();
+  return `${sanitized}-${suffix}`.slice(0, 100);
+}
+
+async function fileToDataUrl(file: File) {
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const mime = file.type || "application/octet-stream";
+  const base64 = buffer.toString("base64");
+  return `data:${mime};base64,${base64}`;
+}
+
+function ensureDataUrl(value: string | null | undefined) {
+  const trimmed = (value ?? "").trim();
+  if (!/^data:[^;]+;base64,/i.test(trimmed)) {
+    throw new Error("INVALID_DATA_URL");
+  }
+  return trimmed;
 }
 
 export async function POST(req: NextRequest) {
@@ -33,28 +50,27 @@ export async function POST(req: NextRequest) {
 
   try {
     const form = await req.formData();
-    const file = form.get("file");
-    if (!file || typeof file === "string") {
+    const entry = form.get("file") ?? form.get("dataUrl");
+    if (!entry) {
       return NextResponse.json({ error: "Arquivo invalido" }, { status: 400 });
     }
 
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const ext = resolveExtension(file);
-    const filename = `public/template-items/${randomUUID()}.${ext}`;
-    const bucket = adminStorage.bucket();
-    const storageFile = bucket.file(filename);
+    let dataUrl: string;
+    let fileName: string | undefined;
+    if (typeof entry === "string") {
+      try {
+        dataUrl = ensureDataUrl(entry);
+      } catch {
+        return NextResponse.json({ error: "DATA_URL_INVALIDA" }, { status: 400 });
+      }
+    } else {
+      dataUrl = await fileToDataUrl(entry);
+      fileName = entry.name;
+    }
 
-    await storageFile.save(buffer, {
-      resumable: false,
-      contentType: file.type || "application/octet-stream",
-    });
-    await storageFile.makePublic();
-    await storageFile.setMetadata({
-      contentType: file.type || "application/octet-stream",
-      cacheControl: "public, max-age=31536000",
-    });
-
-    const url = `https://storage.googleapis.com/${bucket.name}/${filename}`;
+    const formName = form.get("name");
+    const uploadName = buildUploadName(typeof formName === "string" ? formName : undefined, fileName);
+    const { url } = await uploadToImgbbFromDataUrl(dataUrl, uploadName);
     return NextResponse.json({ url });
   } catch (err: unknown) {
     return NextResponse.json(

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -1,0 +1,98 @@
+import { forwardRef } from "react";
+import type { ComponentProps, ReactElement, SVGProps } from "react";
+
+type SvgFactory = (props: SVGProps<SVGSVGElement>) => ReactElement;
+
+const baseSvgProps: Pick<SVGProps<SVGSVGElement>, "fill" | "stroke" | "strokeWidth" | "strokeLinecap" | "strokeLinejoin"> = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.5,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+};
+
+const icons = {
+  plus: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  ),
+  minus: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M5 12h14" />
+    </svg>
+  ),
+  check: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M5 13l4 4L19 7" />
+    </svg>
+  ),
+  x: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M18 6L6 18" />
+      <path d="M6 6l12 12" />
+    </svg>
+  ),
+  upload: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M4 17v3h16v-3" />
+      <path d="M12 3v14" />
+      <path d="M7 8l5-5 5 5" />
+    </svg>
+  ),
+  image: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="M10 13l-2 2" />
+      <path d="M21 15l-3-3-4 4" />
+      <circle cx="8" cy="9" r="1.5" />
+    </svg>
+  ),
+  edit: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4z" />
+    </svg>
+  ),
+  trash: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M4 7h16" />
+      <path d="M10 11v6" />
+      <path d="M14 11v6" />
+      <path d="M5 7l1 12a2 2 0 002 2h8a2 2 0 002-2l1-12" />
+      <path d="M9 7V4h6v3" />
+    </svg>
+  ),
+  chevronRight: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M9 18l6-6-6-6" />
+    </svg>
+  ),
+  chevronLeft: props => (
+    <svg viewBox="0 0 24 24" {...baseSvgProps} {...props}>
+      <path d="M15 18l-6-6 6-6" />
+    </svg>
+  ),
+} satisfies Record<string, SvgFactory>;
+
+export type IconName = keyof typeof icons;
+
+export type IconProps = {
+  name: IconName;
+} & Omit<ComponentProps<"svg">, "children">;
+
+export const Icon = forwardRef<SVGSVGElement, IconProps>(
+  ({ name, width = 24, height = 24, ...props }, ref): ReactElement | null => {
+    const IconComponent = icons[name];
+    if (!IconComponent) {
+      return null;
+    }
+    return IconComponent({ width, height, ref, ...props });
+  }
+);
+
+Icon.displayName = "Icon";
+
+export const availableIcons = Object.freeze(Object.keys(icons)) as ReadonlyArray<IconName>;
+

--- a/src/lib/firebase-admin.ts
+++ b/src/lib/firebase-admin.ts
@@ -2,7 +2,6 @@
 import { getApps, initializeApp, cert, App } from "firebase-admin/app";
 import { getAuth } from "firebase-admin/auth";
 import { getFirestore } from "firebase-admin/firestore";
-import { getStorage } from "firebase-admin/storage";
 
 let adminApp: App;
 if (!getApps().length) {
@@ -20,4 +19,3 @@ if (!getApps().length) {
 
 export const adminAuth = getAuth(adminApp);
 export const adminDb = getFirestore(adminApp);
-export const adminStorage = getStorage(adminApp);

--- a/src/lib/imgbb.ts
+++ b/src/lib/imgbb.ts
@@ -1,0 +1,76 @@
+// src/lib/imgbb.ts
+const DATA_URL_REGEX = /^data:([^;]+);base64,([a-z0-9+/=\r\n]+)$/i;
+
+type UploadResponse = {
+  data?: {
+    url?: string;
+    display_url?: string;
+    delete_url?: string;
+  };
+  success?: boolean;
+  status?: number;
+};
+
+function extractBase64(dataUrl: string) {
+  const trimmed = dataUrl.trim();
+  const match = trimmed.match(DATA_URL_REGEX);
+  if (!match) {
+    throw new Error("INVALID_DATA_URL");
+  }
+  const base64 = match[2]!.replace(/\s+/g, "");
+  if (!base64) {
+    throw new Error("INVALID_DATA_URL");
+  }
+  return base64;
+}
+
+function buildEndpoint(expirationSec?: number) {
+  const apiKey = process.env.IMGBB_API_KEY;
+  if (!apiKey) {
+    throw new Error("IMGBB_API_KEY_NOT_CONFIGURED");
+  }
+  const endpoint = new URL("https://api.imgbb.com/1/upload");
+  endpoint.searchParams.set("key", apiKey);
+  if (typeof expirationSec === "number" && Number.isFinite(expirationSec) && expirationSec > 0) {
+    endpoint.searchParams.set("expiration", Math.floor(expirationSec).toString());
+  }
+  return endpoint.toString();
+}
+
+export async function uploadToImgbbFromDataUrl(
+  dataUrl: string,
+  name?: string,
+  expirationSec?: number
+): Promise<{ url: string; display_url: string; delete_url?: string }> {
+  const base64 = extractBase64(dataUrl);
+  const form = new FormData();
+  form.set("image", base64);
+  if (name && name.trim()) {
+    form.set("name", name.trim());
+  }
+
+  const response = await fetch(buildEndpoint(expirationSec), {
+    method: "POST",
+    body: form,
+  });
+
+  let payload: UploadResponse | null = null;
+  try {
+    payload = (await response.json()) as UploadResponse;
+  } catch (err) {
+    throw new Error(`IMGBB_RESPONSE_ERROR: ${(err as Error)?.message ?? "Unknown"}`);
+  }
+
+  if (!response.ok || payload?.success !== true || !payload.data?.url || !payload.data.display_url) {
+    const status = payload?.status ?? response.status;
+    const message = `IMGBB_UPLOAD_FAILED: status=${status}`;
+    throw new Error(message);
+  }
+
+  return {
+    url: payload.data.url,
+    display_url: payload.data.display_url,
+    delete_url: payload.data.delete_url,
+  };
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- replace Firebase Storage uploads with imgbb for template, template item, machine, and inspection flows using a shared uploader
- add an imgbb helper and typed Icon component to avoid relying on the global JSX namespace
- update Next.js image configuration and remove the Firebase Storage admin export now that uploads use imgbb

## Testing
- npm run typecheck
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68de7a2da91c8328a57ade76c66fb338