### PR TITLE
Fix PCM signature submission and add inspections shortcut

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,7 +1,63 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+
+import { Button, buttonStyles } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+type NavigationItem = {
+  href: string;
+  title: string;
+  description: string;
+  icon: string;
+  accentClass: string;
+};
+
+const navigationItems: NavigationItem[] = [
+  {
+    href: "/admin/nc",
+    title: "Tratativas de NCs",
+    description: "Priorize e acompanhe não conformidades",
+    icon: "fas fa-exclamation-triangle",
+    accentClass: "bg-red-100 text-red-600",
+  },
+  {
+    href: "/admin/inspecoes",
+    title: "Gestão de inspeções",
+    description: "Centralize edição, assinatura e relatórios",
+    icon: "fas fa-clipboard-check",
+    accentClass: "bg-sky-100 text-sky-600",
+  },
+  {
+    href: "/admin/inspecoes/assinar",
+    title: "Assinaturas pendentes",
+    description: "Assine inspeções do PCM com destaque para NCs",
+    icon: "fas fa-file-signature",
+    accentClass: "bg-amber-100 text-amber-600",
+  },
+  {
+    href: "/admin/templates",
+    title: "Templates de checklist",
+    description: "Mantenha os modelos de inspeção atualizados",
+    icon: "fas fa-clipboard-list",
+    accentClass: "bg-purple-100 text-purple-600",
+  },
+  {
+    href: "/admin/maquinas",
+    title: "Máquinas",
+    description: "Gerencie cadastro e status dos equipamentos",
+    icon: "fas fa-cogs",
+    accentClass: "bg-blue-100 text-blue-600",
+  },
+  {
+    href: "/admin/mantenedores",
+    title: "Mantenedores",
+    description: "Controle o acesso e as equipes de manutenção",
+    icon: "fas fa-users-cog",
+    accentClass: "bg-green-100 text-green-600",
+  },
+];
 
 export default function AdminDashboard() {
   const [sessionOk, setSessionOk] = useState(false);
@@ -20,152 +76,146 @@ export default function AdminDashboard() {
     })();
   }, []);
 
+  const footerYear = useMemo(() => new Date().getFullYear(), []);
+
   async function logout() {
     await fetch("/api/admin-session", { method: "DELETE" });
     window.location.href = "/admin/login";
   }
 
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-green-50 to-blue-50">
-        <div className="text-center">
-          <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center mx-auto mb-4">
-            <i className="fas fa-spinner fa-spin text-green-600 text-xl"></i>
-          </div>
-          <p className="text-gray-600">Carregando...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4">
-      <div className="max-w-6xl mx-auto">
-        {/* Cabeçalho */}
-        <div className="flex flex-col md:flex-row md:items-center justify-between mb-8 pt-6">
-          <div className="flex items-center mb-4 md:mb-0">
-            <div className="w-12 h-12 rounded-full bg-green-600 flex items-center justify-center mr-3">
-              <i className="fas fa-tractor text-white text-xl"></i>
+    <div className="min-h-screen bg-[var(--surface)]">
+      <div className="max-w-7xl mx-auto px-4 py-10 space-y-8">
+        <header className="flex flex-col gap-6 border-b border-[var(--border)] pb-8 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-2">
+            <div className="flex items-center gap-3 text-[var(--muted)] text-sm">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-[var(--primary)] text-white">
+                <i className="fas fa-user-shield" aria-hidden />
+              </span>
+              <div>
+                <p className="font-medium text-[var(--text)]">Dashboard do PCM</p>
+                <p className="text-[var(--muted)]">Controle central das inspeções e ativos</p>
+              </div>
             </div>
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">Lar Cooperativa Agroindustrial</h1>
-              <p className="text-gray-600">Sistema de Manutenção de Rotas</p>
-            </div>
+            <h1 className="text-3xl font-semibold text-[var(--text)]">Painel administrativo</h1>
           </div>
-          
+
           {sessionOk && (
-            <button 
-              onClick={logout}
-              className="flex items-center justify-center px-4 py-2 bg-red-500 hover:bg-red-600 text-white rounded-lg transition duration-150 ease-in-out"
-            >
-              <i className="fas fa-sign-out-alt mr-2"></i>
-              Sair
-            </button>
-          )}
-        </div>
-
-        {/* Conteúdo Principal */}
-        <div className="bg-white rounded-2xl shadow-lg p-6 md:p-8">
-          <div className="text-center mb-8">
-            <div className="w-16 h-16 rounded-full bg-green-100 flex items-center justify-center mx-auto mb-4">
-              <i className="fas fa-user-shield text-green-600 text-2xl"></i>
+            <div className="flex items-center gap-3">
+              <span className="inline-flex items-center gap-2 rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-700">
+                <i className="fas fa-check-circle" aria-hidden />
+                Sessão validada
+              </span>
+              <Button variant="destructive" onClick={logout} type="button">
+                <i className="fas fa-sign-out-alt" aria-hidden />
+                Sair
+              </Button>
             </div>
-            <h2 className="text-3xl font-bold text-gray-900 mb-2">Dashboard Admin (PCM)</h2>
-            <p className="text-gray-600">Painel de controle e gestão</p>
-          </div>
+          )}
+        </header>
 
-          {sessionOk ? (
-            <div className="space-y-8">
-              {/* Status de Sessão */}
-              <div className="bg-green-50 border border-green-200 rounded-lg p-4 flex items-center">
-                <i className="fas fa-check-circle text-green-600 text-xl mr-3"></i>
+        {loading ? (
+          <Card>
+            <CardContent className="flex flex-col items-center gap-4 py-12">
+              <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-[var(--surface)] text-[var(--primary)]">
+                <i className="fas fa-spinner fa-spin" aria-hidden />
+              </span>
+              <p className="text-sm text-[var(--muted)]">Validando sessão do PCM...</p>
+            </CardContent>
+          </Card>
+        ) : sessionOk ? (
+          <div className="space-y-8">
+            <section>
+              <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <p className="font-medium text-green-800">Sessão válida</p>
-                  <p className="text-green-600 text-sm">Bem-vindo ao painel administrativo</p>
+                  <h2 className="text-xl font-semibold text-[var(--text)]">Acesso rápido</h2>
+                  <p className="text-sm text-[var(--muted)]">Principais rotinas do PCM em um só lugar</p>
+                </div>
+                <div className="flex flex-wrap gap-3">
+                  <Link href="/admin/nc" className={buttonStyles({ variant: "secondary" })}>
+                    <i className="fas fa-exclamation-circle" aria-hidden />
+                    Abrir tratativas
+                  </Link>
+                  <Link href="/admin/inspecoes" className={buttonStyles({ variant: "outline" })}>
+                    <i className="fas fa-clipboard-check" aria-hidden />
+                    Ver inspeções
+                  </Link>
+                  <Link href="/admin/inspecoes/assinar" className={buttonStyles()}>
+                    <i className="fas fa-pen-fancy" aria-hidden />
+                    Assinar inspeções
+                  </Link>
                 </div>
               </div>
-
-              {/* Grid de Módulos */}
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {/* Mantenedores */}
-                <Link href="/admin/mantenedores">
-                  <div className="bg-white border border-gray-200 rounded-xl p-6 hover:shadow-lg transition duration-150 ease-in-out cursor-pointer group">
-                    <div className="w-12 h-12 rounded-full bg-blue-100 flex items-center justify-center mb-4 group-hover:bg-blue-200 transition duration-150 ease-in-out">
-                      <i className="fas fa-users-cog text-blue-600 text-xl"></i>
-                    </div>
-                    <h3 className="text-xl font-bold text-gray-900 mb-2">Mantenedores</h3>
-                    <p className="text-gray-600 text-sm">Gerencie técnicos e mantenedores do sistema</p>
-                    <div className="mt-4 text-blue-600 font-medium flex items-center">
-                      Acessar <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform duration-150 ease-in-out"></i>
-                    </div>
-                  </div>
-                </Link>
-
-                {/* Templates */}
-                <Link href="/admin/templates">
-                  <div className="bg-white border border-gray-200 rounded-xl p-6 hover:shadow-lg transition duration-150 ease-in-out cursor-pointer group">
-                    <div className="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center mb-4 group-hover:bg-purple-200 transition duration-150 ease-in-out">
-                      <i className="fas fa-clipboard-list text-purple-600 text-xl"></i>
-                    </div>
-                    <h3 className="text-xl font-bold text-gray-900 mb-2">Templates</h3>
-                    <p className="text-gray-600 text-sm">Modelos de checklists e formulários</p>
-                    <div className="mt-4 text-purple-600 font-medium flex items-center">
-                      Acessar <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform duration-150 ease-in-out"></i>
-                    </div>
-                  </div>
-                </Link>
-
-                {/* Máquinas */}
-                <Link href="/admin/maquinas">
-                  <div className="bg-white border border-gray-200 rounded-xl p-6 hover:shadow-lg transition duration-150 ease-in-out cursor-pointer group">
-                    <div className="w-12 h-12 rounded-full bg-orange-100 flex items-center justify-center mb-4 group-hover:bg-orange-200 transition duration-150 ease-in-out">
-                      <i className="fas fa-cogs text-orange-600 text-xl"></i>
-                    </div>
-                    <h3 className="text-xl font-bold text-gray-900 mb-2">Máquinas</h3>
-                    <p className="text-gray-600 text-sm">Cadastro e gestão de equipamentos</p>
-                    <div className="mt-4 text-orange-600 font-medium flex items-center">
-                      Acessar <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform duration-150 ease-in-out"></i>
-                    </div>
-                  </div>
-                </Link>
-
-                {/* Não Conformidades */}
-                <Link href="/admin/nao-conformidades">
-                  <div className="bg-white border border-gray-200 rounded-xl p-6 hover:shadow-lg transition duration-150 ease-in-out cursor-pointer group">
-                    <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center mb-4 group-hover:bg-red-200 transition duration-150 ease-in-out">
-                      <i className="fas fa-exclamation-triangle text-red-600 text-xl"></i>
-                    </div>
-                    <h3 className="text-xl font-bold text-gray-900 mb-2">Não Conformidades</h3>
-                    <p className="text-gray-600 text-sm">Visualize e gerencie inconformidades</p>
-                    <div className="mt-4 text-red-600 font-medium flex items-center">
-                      Acessar <i className="fas fa-arrow-right ml-2 group-hover:translate-x-1 transition-transform duration-150 ease-in-out"></i>
-                    </div>
-                  </div>
-                </Link>
+              <div className="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {navigationItems.map(item => (
+                  <Link key={item.href} href={item.href} className="group focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2">
+                    <Card className="h-full transition-all duration-150 group-hover:border-[var(--primary)] group-hover:shadow-md">
+                      <CardHeader className="flex flex-row items-start gap-4 pb-4">
+                        <span className={`inline-flex h-12 w-12 items-center justify-center rounded-lg ${item.accentClass}`}>
+                          <i className={item.icon} aria-hidden />
+                        </span>
+                        <div>
+                          <CardTitle className="text-lg font-semibold text-[var(--text)]">{item.title}</CardTitle>
+                          <CardDescription>{item.description}</CardDescription>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="pt-0">
+                        <div className="flex items-center gap-2 text-sm font-medium text-[var(--primary)]">
+                          Acessar painel
+                          <i className="fas fa-arrow-right transition-transform duration-150 group-hover:translate-x-1" aria-hidden />
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                ))}
               </div>
-            </div>
-          ) : (
-            <div className="text-center py-8">
-              <div className="w-16 h-16 rounded-full bg-red-100 flex items-center justify-center mx-auto mb-4">
-                <i className="fas fa-exclamation-circle text-red-600 text-2xl"></i>
-              </div>
-              <h3 className="text-xl font-bold text-gray-900 mb-2">Ops! Não autenticado</h3>
-              <p className="text-gray-600 mb-6">Sua sessão expirou ou você não está autorizado</p>
-              <Link 
-                href="/admin/login"
-                className="inline-flex items-center px-6 py-3 bg-green-600 hover:bg-green-700 text-white rounded-lg transition duration-150 ease-in-out"
-              >
-                <i className="fas fa-sign-in-alt mr-2"></i>
+            </section>
+
+            <section>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Orientações</CardTitle>
+                  <CardDescription>
+                    Utilize os atalhos acima para cuidar das não conformidades, assinaturas e cadastro de ativos.
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ul className="list-disc space-y-2 pl-5 text-sm text-[var(--muted)]">
+                    <li>
+                      Priorize inspeções com pendências em <strong>Tratativas de NCs</strong> para reduzir riscos operacionais.
+                    </li>
+                    <li>
+                      Centralize as assinaturas da PCM no módulo <strong>Assinaturas pendentes</strong> para acelerar liberações.
+                    </li>
+                    <li>
+                      Atualize templates, máquinas e equipes diretamente nos respectivos painéis conforme necessário.
+                    </li>
+                  </ul>
+                </CardContent>
+              </Card>
+            </section>
+          </div>
+        ) : (
+          <Card>
+            <CardHeader className="items-center text-center">
+              <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-red-100 text-red-600">
+                <i className="fas fa-exclamation-circle" aria-hidden />
+              </span>
+              <CardTitle className="text-xl">Sessão expirada</CardTitle>
+              <CardDescription>Faça login novamente para acessar o painel administrativo.</CardDescription>
+            </CardHeader>
+            <CardContent className="flex justify-center pb-8">
+              <Link href="/admin/login" className={buttonStyles()}>
+                <i className="fas fa-sign-in-alt" aria-hidden />
                 Ir para login
               </Link>
-            </div>
-          )}
-        </div>
+            </CardContent>
+          </Card>
+        )}
 
-        {/* Rodapé */}
-        <div className="text-center text-gray-500 text-sm mt-8 pb-4">
-          <p>Lar Cooperativa Agroindustrial &copy; {new Date().getFullYear()}</p>
-        </div>
+        <footer className="border-t border-[var(--border)] pt-6 text-center text-sm text-[var(--muted)]">
+          Lar Cooperativa Agroindustrial &copy; {footerYear}
+        </footer>
       </div>
     </div>
   );

--- a/src/app/admin/inspecoes/[id]/edit/page.tsx
+++ b/src/app/admin/inspecoes/[id]/edit/page.tsx
@@ -1,0 +1,699 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { FormEvent } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface TemplateItemData {
+  id?: string;
+  componente?: string;
+  oQueChecar?: string;
+  instrumento?: string;
+  criterio?: string;
+  oQueFazer?: string;
+  ordem?: number;
+}
+
+interface ApiAnswer {
+  questionId: string;
+  questionText?: string | null;
+  response: "c" | "nc" | "na";
+  observation?: string | null;
+  photoUrls?: string[];
+}
+
+interface ApiInspection {
+  id: string;
+  answers?: ApiAnswer[];
+  observacoes?: string | null;
+  osNumero?: string | null;
+  createdAt?: string | null;
+  finalizadaEm?: string | null;
+  maintainer?: {
+    nome?: string | null;
+    matricula?: string | null;
+  } | null;
+  machine?: MachineData | null;
+  qtdNC?: number;
+}
+
+interface ApiResponse {
+  inspection: ApiInspection;
+  template: {
+    id?: string | null;
+    nome?: string | null;
+    versao?: string | null;
+    itens?: TemplateItemData[];
+  } | null;
+  machine: MachineData | null;
+}
+
+interface MachineData {
+  machineId?: string | null;
+  id?: string | null;
+  nome?: string | null;
+  tag?: string | null;
+  setor?: string | null;
+  unidade?: string | null;
+  localUnidade?: string | null;
+  lac?: string | null;
+}
+
+interface NewPhoto {
+  id: string;
+  dataUrl: string;
+  name?: string;
+}
+
+interface FormItem {
+  questionId: string;
+  questionText: string;
+  componente?: string;
+  oQueChecar?: string;
+  instrumento?: string;
+  criterio?: string;
+  oQueFazer?: string;
+  order: number;
+  previousResponse: "c" | "nc" | "na";
+  response: "c" | "nc" | "na";
+  observation: string;
+  existingPhotos: string[];
+  newPhotos: NewPhoto[];
+}
+
+interface FormState {
+  osNumero: string;
+  observacoes: string;
+  items: FormItem[];
+}
+
+function normalizeId(value: string | string[] | undefined): string | null {
+  if (!value) return null;
+  return Array.isArray(value) ? value[0] ?? null : value;
+}
+
+function formatMachineLabel(machine: MachineData | null | undefined) {
+  if (!machine) return "Máquina";
+  const nome = machine.nome ? String(machine.nome) : "Máquina";
+  const tag = machine.tag ? String(machine.tag) : null;
+  return tag ? `${nome} (${tag})` : nome;
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleString("pt-BR");
+}
+
+function generateId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2);
+}
+
+function readFileAsDataUrl(file: File) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Erro ao ler arquivo"));
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function EditInspectionPage() {
+  const params = useParams();
+  const idParam = normalizeId(params?.id as string | string[] | undefined);
+  const router = useRouter();
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState | null>(null);
+  const [machine, setMachine] = useState<MachineData | null>(null);
+  const [templateInfo, setTemplateInfo] = useState<{ nome?: string | null; versao?: string | null } | null>(null);
+  const [operatorLabel, setOperatorLabel] = useState<string>("-");
+  const [dateLabel, setDateLabel] = useState<string>("-");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const inspectionId = idParam ? String(idParam) : null;
+
+  const loadInspection = useCallback(async () => {
+    if (!inspectionId) {
+      setError("Identificador da inspeção não encontrado.");
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const session = await fetch("/api/admin-session", { cache: "no-store" });
+      if (session.status === 401) {
+        window.location.href = "/admin/login";
+        return;
+      }
+
+      const response = await fetch(`/api/inspecoes/${inspectionId}`, { cache: "no-store" });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error || "Falha ao carregar inspeção");
+      }
+      const data = (await response.json()) as ApiResponse;
+      const inspection = data.inspection ?? { id: inspectionId };
+      const template = data.template ?? null;
+      const machineData = inspection.machine ?? data.machine ?? null;
+      const answers = Array.isArray(inspection.answers) ? inspection.answers : [];
+
+      const templateItems = Array.isArray(template?.itens) ? template.itens : [];
+      const templateMap = new Map<string, TemplateItemData>();
+      templateItems.forEach(item => {
+        if (item?.id) templateMap.set(String(item.id), item);
+      });
+
+      const answersMap = new Map<string, ApiAnswer>();
+      answers.forEach(answer => {
+        if (answer?.questionId) answersMap.set(answer.questionId, answer);
+      });
+
+      const formItems: FormItem[] = templateItems.map((item, index) => {
+        const answer = item.id ? answersMap.get(String(item.id)) : undefined;
+        const response = answer?.response ?? "c";
+        return {
+          questionId: item.id ? String(item.id) : `template-${index}`,
+          questionText:
+            answer?.questionText ||
+            item.oQueChecar ||
+            item.criterio ||
+            item.componente ||
+            `Item ${index + 1}`,
+          componente: item.componente,
+          oQueChecar: item.oQueChecar,
+          instrumento: item.instrumento,
+          criterio: item.criterio,
+          oQueFazer: item.oQueFazer,
+          order: typeof item.ordem === "number" ? item.ordem : index,
+          previousResponse: response,
+          response,
+          observation: answer?.observation ?? "",
+          existingPhotos: Array.isArray(answer?.photoUrls) ? answer!.photoUrls!.filter(Boolean) : [],
+          newPhotos: [],
+        };
+      });
+
+      answers.forEach(answer => {
+        if (answer?.questionId && !templateMap.has(answer.questionId)) {
+          formItems.push({
+            questionId: answer.questionId,
+            questionText: answer.questionText ?? `Item ${answer.questionId}`,
+            componente: undefined,
+            oQueChecar: undefined,
+            instrumento: undefined,
+            criterio: undefined,
+            oQueFazer: undefined,
+            order: Number.MAX_SAFE_INTEGER,
+            previousResponse: answer.response,
+            response: answer.response,
+            observation: answer.observation ?? "",
+            existingPhotos: Array.isArray(answer.photoUrls) ? answer.photoUrls.filter(Boolean) : [],
+            newPhotos: [],
+          });
+        }
+      });
+
+      formItems.sort((a, b) => a.order - b.order);
+
+      setForm({
+        osNumero: inspection.osNumero ?? "",
+        observacoes: inspection.observacoes ?? "",
+        items: formItems,
+      });
+      setMachine(machineData);
+      setTemplateInfo({ nome: template?.nome ?? null, versao: template?.versao ?? null });
+
+      const maintainer = inspection.maintainer ?? null;
+      const operator = maintainer?.nome ? String(maintainer.nome) : "-";
+      const matricula = maintainer?.matricula ? ` (${maintainer.matricula})` : "";
+      setOperatorLabel(`${operator}${matricula}`);
+      const date = inspection.finalizadaEm ?? inspection.createdAt ?? null;
+      setDateLabel(formatDateTime(date));
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Erro ao carregar inspeção";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [inspectionId]);
+
+  useEffect(() => {
+    loadInspection();
+  }, [loadInspection]);
+
+  const hasNonConformity = useMemo(() => {
+    return form?.items.some(item => item.response === "nc") ?? false;
+  }, [form]);
+
+  const handleResponseChange = useCallback((questionId: string, response: "c" | "nc" | "na") => {
+    setForm(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        items: prev.items.map(item => (item.questionId === questionId ? { ...item, response } : item)),
+      };
+    });
+  }, []);
+
+  const handleObservationChange = useCallback((questionId: string, value: string) => {
+    setForm(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        items: prev.items.map(item => (item.questionId === questionId ? { ...item, observation: value } : item)),
+      };
+    });
+  }, []);
+
+  const handleAddPhotos = useCallback(async (questionId: string, files: FileList | null) => {
+    if (!files?.length) return;
+    const selected = Array.from(files);
+    setForm(prev => {
+      if (!prev) return prev;
+      const target = prev.items.find(item => item.questionId === questionId);
+      if (!target) return prev;
+      const currentCount = target.existingPhotos.length + target.newPhotos.length;
+      const available = Math.max(0, 3 - currentCount);
+      if (available <= 0) {
+        return prev;
+      }
+      const allowedFiles = selected.slice(0, available);
+      setSaveError(null);
+      Promise.all(allowedFiles.map(file => readFileAsDataUrl(file)))
+        .then(dataUrls => {
+          setForm(innerPrev => {
+            if (!innerPrev) return innerPrev;
+            return {
+              ...innerPrev,
+              items: innerPrev.items.map(item => {
+                if (item.questionId !== questionId) return item;
+                const newPhotos = dataUrls.map((dataUrl, index) => ({
+                  id: generateId(),
+                  dataUrl,
+                  name: allowedFiles[index]?.name,
+                }));
+                return { ...item, newPhotos: [...item.newPhotos, ...newPhotos] };
+              }),
+            };
+          });
+        })
+        .catch(err => {
+          const message = err instanceof Error && err.message ? err.message : "Erro ao processar imagem";
+          setSaveError(message);
+        });
+      return prev;
+    });
+  }, []);
+
+  const handleRemoveNewPhoto = useCallback((questionId: string, photoId: string) => {
+    setForm(prev => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        items: prev.items.map(item => {
+          if (item.questionId !== questionId) return item;
+          return { ...item, newPhotos: item.newPhotos.filter(photo => photo.id !== photoId) };
+        }),
+      };
+    });
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!inspectionId || !form) return;
+      try {
+        setSaving(true);
+        setSaveError(null);
+        setSaveSuccess(null);
+
+        const itensPayload = form.items.map(item => {
+          const photosPayload: Array<string | { dataUrl: string; name?: string } | undefined> = [];
+          item.existingPhotos.forEach(url => {
+            photosPayload.push(url);
+          });
+          item.newPhotos.forEach(photo => {
+            photosPayload.push({ dataUrl: photo.dataUrl, name: photo.name });
+          });
+          return {
+            questionId: item.questionId,
+            response: item.response,
+            observation: item.observation.trim() ? item.observation.trim() : undefined,
+            photoUrls: photosPayload.length > 0 ? photosPayload : undefined,
+          };
+        });
+
+        const payload = {
+          osNumero: form.osNumero.trim() ? form.osNumero.trim() : undefined,
+          observacoes: form.observacoes.trim() ? form.observacoes.trim() : undefined,
+          itens: itensPayload,
+        };
+
+        const response = await fetch(`/api/inspecoes/${inspectionId}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => null);
+          throw new Error(data?.error || "Falha ao salvar inspeção");
+        }
+
+        setSaveSuccess("Inspeção atualizada com sucesso.");
+        await loadInspection();
+      } catch (err: unknown) {
+        const message = err instanceof Error && err.message ? err.message : "Erro ao salvar alterações";
+        setSaveError(message);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [form, inspectionId, loadInspection]
+  );
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-6 p-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-[var(--text)]">Editar inspeção</h1>
+        </header>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-1/3" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-24 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto space-y-6 p-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold text-[var(--text)]">Editar inspeção</h1>
+          <Button variant="secondary" onClick={() => loadInspection()}>
+            Recarregar
+          </Button>
+        </header>
+        <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_80%)] px-4 py-3 text-[var(--danger)]">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  if (!form || !inspectionId) {
+    return null;
+  }
+
+  const machineLabel = formatMachineLabel(machine);
+  const locationLabel = machine
+    ? [machine.unidade, machine.localUnidade, machine.setor].filter(Boolean).join(" • ")
+    : "";
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6 p-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-semibold text-[var(--text)]">Editar inspeção</h1>
+            {hasNonConformity ? (
+              <Badge variant="danger">Com NC</Badge>
+            ) : (
+              <Badge variant="success">Sem NC</Badge>
+            )}
+          </div>
+          <p className="text-sm text-[var(--muted)]">Revise as respostas e atualize as tratativas conforme necessário.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button variant="ghost" type="button" onClick={() => router.back()}>
+            Cancelar
+          </Button>
+          <Link
+            href={`/api/inspecoes/${inspectionId}/pdf`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block"
+          >
+            <Button type="button" variant="secondary">
+              Ver PDF
+            </Button>
+          </Link>
+        </div>
+      </header>
+
+      <Card>
+        <CardHeader className="space-y-3">
+          <CardTitle className="text-xl text-[var(--text)]">{machineLabel}</CardTitle>
+          {locationLabel && <p className="text-sm text-[var(--muted)]">{locationLabel}</p>}
+          <div className="grid gap-2 text-sm text-[var(--muted)] md:grid-cols-3">
+            <div>
+              <span className="font-medium text-[var(--text)]">LAC:</span> {machine?.lac ?? "-"}
+            </div>
+            <div>
+              <span className="font-medium text-[var(--text)]">Operador:</span> {operatorLabel}
+            </div>
+            <div>
+              <span className="font-medium text-[var(--text)]">Data:</span> {dateLabel}
+            </div>
+          </div>
+          <div className="text-sm text-[var(--muted)]">
+            Template: {templateInfo?.nome ?? "-"}
+            {templateInfo?.versao ? ` (versão ${templateInfo.versao})` : ""}
+          </div>
+        </CardHeader>
+      </Card>
+
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg text-[var(--text)]">Dados gerais</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className="text-[var(--muted)]">Número da O.S.</span>
+                <Input
+                  value={form.osNumero}
+                  onChange={event => setForm(prev => (prev ? { ...prev, osNumero: event.target.value } : prev))}
+                  placeholder="Informe o número da OS"
+                />
+              </label>
+              <label className="space-y-1 text-sm md:col-span-2">
+                <span className="text-[var(--muted)]">Observações gerais</span>
+                <Textarea
+                  value={form.observacoes}
+                  onChange={event => setForm(prev => (prev ? { ...prev, observacoes: event.target.value } : prev))}
+                  placeholder="Anote observações relevantes"
+                />
+              </label>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-4">
+          {form.items.map(item => {
+            const warnResolve = item.previousResponse === "nc" && item.response !== "nc";
+            const warnCreate = item.previousResponse !== "nc" && item.response === "nc";
+            const availableSlots = Math.max(0, 3 - (item.existingPhotos.length + item.newPhotos.length));
+            return (
+              <section
+                key={item.questionId}
+                className="rounded-xl border border-[var(--border)] bg-white p-6 shadow-sm"
+              >
+                <div className="space-y-3">
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h3 className="text-lg font-semibold text-[var(--text)]">{item.questionText}</h3>
+                      {item.criterio && (
+                        <p className="text-sm text-[var(--muted)]">Critério: {item.criterio}</p>
+                      )}
+                    </div>
+                    <div className="flex gap-2">
+                      <label className="inline-flex items-center gap-2 text-sm text-[var(--text)]">
+                        <input
+                          type="radio"
+                          name={`response-${item.questionId}`}
+                          value="c"
+                          checked={item.response === "c"}
+                          onChange={() => handleResponseChange(item.questionId, "c")}
+                        />
+                        Conformidade
+                      </label>
+                      <label className="inline-flex items-center gap-2 text-sm text-[var(--text)]">
+                        <input
+                          type="radio"
+                          name={`response-${item.questionId}`}
+                          value="nc"
+                          checked={item.response === "nc"}
+                          onChange={() => handleResponseChange(item.questionId, "nc")}
+                        />
+                        Não conformidade
+                      </label>
+                      <label className="inline-flex items-center gap-2 text-sm text-[var(--text)]">
+                        <input
+                          type="radio"
+                          name={`response-${item.questionId}`}
+                          value="na"
+                          checked={item.response === "na"}
+                          onChange={() => handleResponseChange(item.questionId, "na")}
+                        />
+                        Não se aplica
+                      </label>
+                    </div>
+                  </div>
+
+                  <div className="grid gap-3 text-sm text-[var(--muted)] md:grid-cols-2">
+                    {item.componente && (
+                      <div>
+                        <span className="font-medium text-[var(--text)]">Componente:</span> {item.componente}
+                      </div>
+                    )}
+                    {item.instrumento && (
+                      <div>
+                        <span className="font-medium text-[var(--text)]">Instrumento:</span> {item.instrumento}
+                      </div>
+                    )}
+                    {item.oQueFazer && (
+                      <div className="md:col-span-2">
+                        <span className="font-medium text-[var(--text)]">O que fazer:</span> {item.oQueFazer}
+                      </div>
+                    )}
+                  </div>
+
+                  {warnResolve && (
+                    <div className="rounded-lg border border-[var(--primary)] bg-[color-mix(in_oklab,var(--primary),#fff_85%)] px-4 py-3 text-sm text-[var(--primary-700)]">
+                      Esta tratativa será encerrada como resolvida ao salvar.
+                    </div>
+                  )}
+                  {warnCreate && (
+                    <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_85%)] px-4 py-3 text-sm text-[var(--danger)]">
+                      Uma nova tratativa será aberta para este item.
+                    </div>
+                  )}
+
+                  <label className="space-y-1 text-sm">
+                    <span className="text-[var(--muted)]">Observação do item</span>
+                    <Textarea
+                      value={item.observation}
+                      onChange={event => handleObservationChange(item.questionId, event.target.value)}
+                      placeholder="Detalhe o ocorrido"
+                    />
+                  </label>
+
+                  {item.existingPhotos.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium text-[var(--text)]">Fotos existentes</p>
+                      <div className="flex flex-wrap gap-3">
+                        {item.existingPhotos.map((photo, index) => (
+                          <div
+                            key={`${item.questionId}-existing-${index}`}
+                            className="overflow-hidden rounded-lg border border-[var(--border)] bg-white"
+                          >
+                            <Image
+                              src={photo}
+                              alt={`Foto existente ${index + 1}`}
+                              width={160}
+                              height={120}
+                              className="h-24 w-40 object-cover"
+                              unoptimized
+                            />
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  {item.newPhotos.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium text-[var(--text)]">Novas fotos</p>
+                      <div className="flex flex-wrap gap-3">
+                        {item.newPhotos.map(photo => (
+                          <div
+                            key={photo.id}
+                            className="relative overflow-hidden rounded-lg border border-[var(--border)] bg-white"
+                          >
+                            <Image
+                              src={photo.dataUrl}
+                              alt="Nova foto"
+                              width={160}
+                              height={120}
+                              className="h-24 w-40 object-cover"
+                              unoptimized
+                            />
+                            <button
+                              type="button"
+                              className="absolute right-1 top-1 rounded-full bg-black/60 px-2 py-1 text-xs text-white"
+                              onClick={() => handleRemoveNewPhoto(item.questionId, photo.id)}
+                            >
+                              remover
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
+                  <label className="space-y-1 text-sm">
+                    <span className="text-[var(--muted)]">Adicionar novas fotos (máx. 3)</span>
+                    <Input
+                      type="file"
+                      accept="image/*"
+                      multiple
+                      disabled={availableSlots <= 0}
+                      onChange={event => {
+                        handleAddPhotos(item.questionId, event.target.files);
+                        event.target.value = "";
+                      }}
+                    />
+                    {availableSlots <= 0 && (
+                      <span className="text-xs text-[var(--muted)]">Limite de fotos atingido para este item.</span>
+                    )}
+                  </label>
+                </div>
+              </section>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1 text-sm">
+            {saveError && <p className="text-[var(--danger)]">{saveError}</p>}
+            {saveSuccess && <p className="text-[var(--primary-700)]">{saveSuccess}</p>}
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="button" variant="ghost" onClick={() => router.back()} disabled={saving}>
+              Cancelar
+            </Button>
+            <Button type="submit" loading={saving}>
+              Salvar alterações
+            </Button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/admin/inspecoes/assinar/page.tsx
+++ b/src/app/admin/inspecoes/assinar/page.tsx
@@ -1,0 +1,709 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
+import Image from "next/image";
+import { useSearchParams } from "next/navigation";
+import { createPortal } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import SignatureCanvas, { SignatureCanvasInstance } from "@/components/signature-canvas-client";
+import { cn } from "@/lib/cn";
+import type { ChecklistAnswer, ChecklistResponse } from "@/types";
+
+interface PendingSignInspection {
+  id: string;
+  machineId: string | null;
+  templateId: string | null;
+  createdAt: string | null;
+  operatorNome: string | null;
+  operatorMatricula: string | null;
+  hasNC: boolean;
+  qtdNC: number;
+  machineTag: string | null;
+  machineNome: string | null;
+}
+
+interface InspectionDetailData {
+  inspection: ChecklistResponse;
+  template: Record<string, unknown> | null;
+  machine: ChecklistResponse["machine"] | null;
+}
+
+interface SignatureModalProps {
+  open: boolean;
+  onClose(): void;
+  onConfirm(): void;
+  nome: string;
+  cargo: string;
+  onNomeChange(value: string): void;
+  onCargoChange(value: string): void;
+  loading: boolean;
+  error: string | null;
+  canvasRef: MutableRefObject<SignatureCanvasInstance | null>;
+  onClear(): void;
+  detail: InspectionDetailData | null;
+  detailLoading: boolean;
+  detailError: string | null;
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleString("pt-BR");
+}
+
+const responseLabels: Record<ChecklistAnswer["response"], string> = {
+  c: "Conforme",
+  nc: "Não conforme",
+  na: "Não se aplica",
+};
+
+const responseBadgeVariant: Record<ChecklistAnswer["response"], "success" | "danger" | "muted"> = {
+  c: "success",
+  nc: "danger",
+  na: "muted",
+};
+
+function SearchParamSync({ onChange }: { onChange: (value: string | null) => void }) {
+  const searchParams = useSearchParams();
+  const inspecao = searchParams.get("inspecao");
+
+  useEffect(() => {
+    onChange(inspecao);
+  }, [inspecao, onChange]);
+
+  return null;
+}
+
+function SignatureModal({
+  open,
+  onClose,
+  onConfirm,
+  nome,
+  cargo,
+  onNomeChange,
+  onCargoChange,
+  loading,
+  error,
+  canvasRef,
+  onClear,
+  detail,
+  detailLoading,
+  detailError,
+}: SignatureModalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (open && canvasRef.current) {
+      canvasRef.current.clear();
+    }
+  }, [open, canvasRef]);
+
+  if (!mounted || !open) return null;
+
+  const answers: ChecklistAnswer[] = Array.isArray(detail?.inspection?.answers)
+    ? (detail?.inspection?.answers as ChecklistAnswer[])
+    : [];
+
+  const inspectionInfo = detail?.inspection ?? null;
+  const machineInfo = inspectionInfo?.machine ?? null;
+  const maintainer = inspectionInfo?.maintainer ?? null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[calc(100vh-2rem)] w-full max-w-5xl overflow-y-auto rounded-xl bg-white p-6 shadow-xl"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--text)]">Revisar inspeção antes de assinar</h2>
+            <p className="text-sm text-[var(--muted)]">
+              Confira os detalhes registrados e confirme a assinatura para concluir o processo.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="rounded-full p-1 text-[var(--muted)] hover:bg-[var(--surface)]"
+            onClick={onClose}
+            aria-label="Fechar"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="mt-6 space-y-6">
+          <section className="space-y-4">
+            <h3 className="text-base font-semibold text-[var(--text)]">Resumo da inspeção</h3>
+            {detailLoading ? (
+              <div className="space-y-4">
+                <Skeleton className="h-20 w-full" />
+                <Skeleton className="h-40 w-full" />
+              </div>
+            ) : detailError ? (
+              <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_85%)] px-4 py-3 text-[var(--danger)]">
+                {detailError}
+              </div>
+            ) : inspectionInfo ? (
+              <div className="space-y-4">
+                <div className="rounded-lg border border-[var(--border)] bg-[var(--surface)] p-4">
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <p className="text-sm font-medium text-[var(--muted)]">Máquina</p>
+                      <p className="text-sm text-[var(--text)]">
+                        {machineInfo?.nome ?? "-"}
+                        {machineInfo?.tag ? ` (${machineInfo.tag})` : ""}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-[var(--muted)]">Data/Hora</p>
+                      <p className="text-sm text-[var(--text)]">
+                        {formatDateTime(inspectionInfo.finalizadaEm ?? inspectionInfo.createdAt ?? null)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-[var(--muted)]">Operador</p>
+                      <p className="text-sm text-[var(--text)]">
+                        {maintainer?.nome ?? "-"}
+                        {maintainer?.matricula ? ` (${maintainer.matricula})` : ""}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-[var(--muted)]">Nº da O.S.</p>
+                      <p className="text-sm text-[var(--text)]">{inspectionInfo.osNumero ?? "-"}</p>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <p className="text-sm font-medium text-[var(--muted)]">Observações gerais</p>
+                      <p className="text-sm text-[var(--text)] whitespace-pre-line">
+                        {inspectionInfo.observacoes?.trim() ? inspectionInfo.observacoes : "Sem observações adicionais."}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-sm font-semibold text-[var(--text)]">Itens avaliados</h4>
+                    <Badge variant={inspectionInfo.qtdNC && inspectionInfo.qtdNC > 0 ? "danger" : "success"}>
+                      {inspectionInfo.qtdNC && inspectionInfo.qtdNC > 0
+                        ? `${inspectionInfo.qtdNC} NC`
+                        : "Sem NC"}
+                    </Badge>
+                  </div>
+                  {answers.length === 0 ? (
+                    <EmptyState
+                      title="Sem itens registrados"
+                      description="Não foi possível localizar as respostas desta inspeção."
+                      className="py-10"
+                    />
+                  ) : (
+                    <div className="space-y-3">
+                      {answers.map(answer => (
+                        <div
+                          key={answer.questionId}
+                          className={cn(
+                            "rounded-lg border p-4",
+                            answer.response === "nc"
+                              ? "border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_92%)]"
+                              : "border-[var(--border)] bg-white"
+                          )}
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <p className="text-sm font-medium text-[var(--text)]">
+                              {answer.questionText ?? `Item ${answer.questionId}`}
+                            </p>
+                            <Badge variant={responseBadgeVariant[answer.response]}>
+                              {responseLabels[answer.response]}
+                            </Badge>
+                          </div>
+                          {answer.recurrence ? (
+                            <div className="mt-2">
+                              <Badge variant="warning">Reincidência</Badge>
+                            </div>
+                          ) : null}
+                          {answer.observation?.trim() ? (
+                            <p className="mt-2 text-sm text-[var(--text)]">
+                              <span className="font-medium text-[var(--muted)]">Observação:</span> {answer.observation}
+                            </p>
+                          ) : null}
+                          {Array.isArray(answer.photoUrls) && answer.photoUrls.length > 0 ? (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              {answer.photoUrls.map((url, index) => (
+                                <div key={`${answer.questionId}-photo-${index}`} className="overflow-hidden rounded-md border">
+                                  <Image
+                                    src={url}
+                                    alt={`Foto da inspeção - item ${answer.questionId}`}
+                                    width={160}
+                                    height={120}
+                                    className="h-24 w-40 object-cover"
+                                    unoptimized
+                                  />
+                                </div>
+                              ))}
+                            </div>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <EmptyState
+                title="Inspeção não encontrada"
+                description="Não foi possível carregar os detalhes desta inspeção."
+                className="py-10"
+              />
+            )}
+          </section>
+
+          <section className="space-y-4">
+            <h3 className="text-base font-semibold text-[var(--text)]">Assinatura do PCM</h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className="text-[var(--muted)]">Nome *</span>
+                <Input value={nome} onChange={event => onNomeChange(event.target.value)} placeholder="Digite o nome" />
+              </label>
+              <label className="space-y-1 text-sm">
+                <span className="text-[var(--muted)]">Cargo</span>
+                <Input value={cargo} onChange={event => onCargoChange(event.target.value)} placeholder="Cargo (opcional)" />
+              </label>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm text-[var(--muted)]">
+                <span>Assinatura</span>
+                <Button type="button" variant="ghost" onClick={onClear} disabled={loading || detailLoading}>
+                  Limpar
+                </Button>
+              </div>
+              <div className="overflow-hidden rounded-lg border border-[var(--border)] bg-white">
+                <SignatureCanvas
+                  ref={canvasRef}
+                  penColor="#111827"
+                  canvasProps={{ className: "h-48 w-full" }}
+                />
+              </div>
+            </div>
+            {error && <p className="text-sm text-[var(--danger)]">{error}</p>}
+          </section>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+            <Button type="button" variant="ghost" onClick={onClose} disabled={loading}>
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              onClick={onConfirm}
+              loading={loading}
+              disabled={loading || detailLoading}
+            >
+              Confirmar assinatura
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export default function PendingSignaturesPage() {
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState<PendingSignInspection[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<PendingSignInspection | null>(null);
+  const [nome, setNome] = useState("");
+  const [cargo, setCargo] = useState("");
+  const [modalError, setModalError] = useState<string | null>(null);
+  const [modalLoading, setModalLoading] = useState(false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [handledParam, setHandledParam] = useState<string | null>(null);
+  const [pendingInspectionId, setPendingInspectionId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<InspectionDetailData | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const signatureRef = useRef<SignatureCanvasInstance | null>(null);
+  const detailAbortRef = useRef<AbortController | null>(null);
+  const broadcastRef = useRef<BroadcastChannel | null>(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSuccessMessage(null);
+    try {
+      const session = await fetch("/api/admin-session", { cache: "no-store" });
+      if (session.status === 401) {
+        window.location.href = "/admin/login";
+        return;
+      }
+
+      const response = await fetch("/api/inspecoes/pending-sign", { cache: "no-store" });
+      if (!response.ok) {
+        const payload = await response.json().catch(() => null);
+        throw new Error(payload?.error || "Falha ao carregar inspeções");
+      }
+      const data = (await response.json()) as PendingSignInspection[];
+      setItems(Array.isArray(data) ? data : []);
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Erro ao carregar inspeções";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("BroadcastChannel" in window)) {
+      return undefined;
+    }
+    const channel = new BroadcastChannel("pcm-inspecoes-events");
+    broadcastRef.current = channel;
+    return () => {
+      channel.close();
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      detailAbortRef.current?.abort();
+    };
+  }, []);
+
+  const filteredItems = useMemo(() => {
+    if (!search.trim()) return items;
+    const term = search.trim().toLowerCase();
+    return items.filter(item => {
+      const machine = `${item.machineNome ?? ""} ${item.machineTag ?? ""}`.toLowerCase();
+      const operator = `${item.operatorNome ?? ""} ${item.operatorMatricula ?? ""}`.toLowerCase();
+      return machine.includes(term) || operator.includes(term);
+    });
+  }, [items, search]);
+
+  const withNc = filteredItems.filter(item => item.hasNC);
+  const withoutNc = filteredItems.filter(item => !item.hasNC);
+
+  const fetchDetail = useCallback(
+    async (inspectionId: string) => {
+      if (!inspectionId) return;
+      detailAbortRef.current?.abort();
+      const controller = new AbortController();
+      detailAbortRef.current = controller;
+      setDetailLoading(true);
+      setDetailError(null);
+      setDetail(null);
+      try {
+        const response = await fetch(`/api/inspecoes/${inspectionId}`, {
+          cache: "no-store",
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(payload?.error || "Não foi possível carregar a inspeção");
+        }
+        const data = (await response.json()) as InspectionDetailData;
+        if (!controller.signal.aborted) {
+          setDetail(data);
+        }
+      } catch (err: unknown) {
+        if (controller.signal.aborted) return;
+        const message = err instanceof Error && err.message ? err.message : "Erro ao carregar inspeção";
+        setDetailError(message);
+      } finally {
+        if (!controller.signal.aborted) {
+          setDetailLoading(false);
+        }
+      }
+    },
+    []
+  );
+
+  const openModal = useCallback(
+    (inspection: PendingSignInspection) => {
+      setSelected(inspection);
+      setNome("");
+      setCargo("");
+      setModalError(null);
+      setDetail(null);
+      setDetailError(null);
+      fetchDetail(inspection.id);
+      setTimeout(() => signatureRef.current?.clear(), 0);
+    },
+    [fetchDetail]
+  );
+
+  const closeModal = useCallback(() => {
+    detailAbortRef.current?.abort();
+    setSelected(null);
+    setNome("");
+    setCargo("");
+    setModalError(null);
+    setDetail(null);
+    setDetailError(null);
+    setDetailLoading(false);
+    signatureRef.current?.clear();
+  }, []);
+
+  useEffect(() => {
+    if (!pendingInspectionId) {
+      setHandledParam(null);
+      return;
+    }
+    if (loading) return;
+    if (handledParam === pendingInspectionId) return;
+    const match = items.find(item => item.id === pendingInspectionId);
+    if (match) {
+      openModal(match);
+      setHandledParam(pendingInspectionId);
+    }
+  }, [handledParam, items, loading, openModal, pendingInspectionId]);
+
+  const handleClearSignature = useCallback(() => {
+    signatureRef.current?.clear();
+  }, []);
+
+  const handleConfirmSignature = useCallback(async () => {
+    if (!selected) return;
+    if (!nome.trim()) {
+      setModalError("Informe o nome do PCM");
+      return;
+    }
+    if (!signatureRef.current || signatureRef.current.isEmpty()) {
+      setModalError("Desenhe a assinatura antes de confirmar");
+      return;
+    }
+
+    try {
+      setModalLoading(true);
+      setModalError(null);
+      const assinaturaDataUrl = signatureRef.current.getTrimmedCanvas().toDataURL("image/png");
+      const payload = {
+        nome: nome.trim(),
+        cargo: cargo.trim() ? cargo.trim() : undefined,
+        assinaturaDataUrl,
+      };
+
+      const response = await fetch(`/api/inspecoes/${selected.id}/pcm-sign`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        throw new Error(data?.error || "Não foi possível registrar a assinatura");
+      }
+
+      setItems(prev => prev.filter(item => item.id !== selected.id));
+      setSuccessMessage("Assinatura registrada com sucesso.");
+      if (broadcastRef.current) {
+        const signedAtIso = new Date().toISOString();
+        broadcastRef.current.postMessage({
+          type: "inspection-signed",
+          id: selected.id,
+          nome: payload.nome,
+          cargo: payload.cargo ?? null,
+          signedAt: signedAtIso,
+        });
+      }
+      closeModal();
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Erro ao registrar assinatura";
+      setModalError(message);
+    } finally {
+      setModalLoading(false);
+    }
+  }, [cargo, closeModal, nome, selected]);
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-6 p-6">
+        <Suspense fallback={null}>
+          <SearchParamSync onChange={setPendingInspectionId} />
+        </Suspense>
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-[var(--text)]">Assinaturas pendentes</h1>
+            <p className="text-sm text-[var(--muted)]">Inspeções aguardando assinatura do PCM.</p>
+          </div>
+          <Input placeholder="Buscar por máquina ou operador" disabled />
+        </header>
+        <div className="grid gap-4 md:grid-cols-2">
+          {[0, 1, 2, 3].map(key => (
+            <Card key={key}>
+              <CardHeader>
+                <Skeleton className="h-6 w-1/2" />
+              </CardHeader>
+              <CardContent className="space-y-3">
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-2/3" />
+                <Skeleton className="h-10 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto space-y-6 p-6">
+        <Suspense fallback={null}>
+          <SearchParamSync onChange={setPendingInspectionId} />
+        </Suspense>
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-[var(--text)]">Assinaturas pendentes</h1>
+            <p className="text-sm text-[var(--muted)]">Inspeções aguardando assinatura do PCM.</p>
+          </div>
+          <Button variant="secondary" onClick={() => loadData()}>
+            Recarregar
+          </Button>
+        </header>
+        <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_80%)] px-4 py-3 text-[var(--danger)]">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6 p-6">
+      <Suspense fallback={null}>
+        <SearchParamSync onChange={setPendingInspectionId} />
+      </Suspense>
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex-1">
+          <h1 className="text-2xl font-semibold text-[var(--text)]">Assinaturas pendentes</h1>
+          <p className="text-sm text-[var(--muted)]">
+            Priorize as inspeções com não conformidades antes de concluir as demais.
+          </p>
+        </div>
+        <Input
+          className="w-full sm:w-80"
+          placeholder="Buscar por TAG ou operador"
+          value={search}
+          onChange={event => setSearch(event.target.value)}
+        />
+      </header>
+
+      {successMessage && (
+        <div className="rounded-lg border border-[var(--primary)] bg-[color-mix(in_oklab,var(--primary),#fff_80%)] px-4 py-3 text-[var(--primary-700)]">
+          {successMessage}
+        </div>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--text)]">Com não conformidade</h2>
+            <p className="text-sm text-[var(--muted)]">Inspeções que registraram NCs exigem sua atenção prioritária.</p>
+          </div>
+          {withNc.length === 0 ? (
+            <EmptyState title="Nenhuma inspeção com NC" description="Tudo em dia por aqui." className="py-10" />
+          ) : (
+            <div className="space-y-4">
+              {withNc.map(item => (
+                <Card key={item.id} className="border-2 border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_92%)]">
+                  <CardHeader className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="danger">{item.qtdNC} NC</Badge>
+                    </div>
+                    <CardTitle className="text-lg text-[var(--text)]">
+                      {item.machineNome ?? "Máquina"} {item.machineTag ? `(${item.machineTag})` : ""}
+                    </CardTitle>
+                    <p className="text-sm text-[var(--muted)]">
+                      Operador: {item.operatorNome || "-"}
+                      {item.operatorMatricula ? ` (${item.operatorMatricula})` : ""}
+                    </p>
+                    <p className="text-sm text-[var(--muted)]">Realizada em {formatDateTime(item.createdAt)}</p>
+                  </CardHeader>
+                  <CardContent className="flex items-center justify-between">
+                    <div className="text-sm text-[var(--muted)]">
+                      Assinatura do PCM pendente.
+                    </div>
+                    <Button onClick={() => openModal(item)}>Assinar</Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold text-[var(--text)]">Sem não conformidade</h2>
+            <p className="text-sm text-[var(--muted)]">Inspeções aprovadas que aguardam apenas sua assinatura.</p>
+          </div>
+          {withoutNc.length === 0 ? (
+            <EmptyState title="Nenhuma inspeção pendente" description="Nenhuma assinatura aguardando nesta lista." className="py-10" />
+          ) : (
+            <div className="space-y-4">
+              {withoutNc.map(item => (
+                <Card key={item.id} className="border border-[var(--border)] bg-[var(--surface)]">
+                  <CardHeader className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Badge variant="success">Sem NC</Badge>
+                    </div>
+                    <CardTitle className="text-lg text-[var(--text)]">
+                      {item.machineNome ?? "Máquina"} {item.machineTag ? `(${item.machineTag})` : ""}
+                    </CardTitle>
+                    <p className="text-sm text-[var(--muted)]">
+                      Operador: {item.operatorNome || "-"}
+                      {item.operatorMatricula ? ` (${item.operatorMatricula})` : ""}
+                    </p>
+                    <p className="text-sm text-[var(--muted)]">Realizada em {formatDateTime(item.createdAt)}</p>
+                  </CardHeader>
+                  <CardContent className="flex items-center justify-between">
+                    <div className="text-sm text-[var(--muted)]">Pronta para ser assinada.</div>
+                    <Button variant="secondary" onClick={() => openModal(item)}>
+                      Assinar
+                    </Button>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <SignatureModal
+        open={Boolean(selected)}
+        onClose={closeModal}
+        onConfirm={handleConfirmSignature}
+        nome={nome}
+        cargo={cargo}
+        onNomeChange={setNome}
+        onCargoChange={setCargo}
+        loading={modalLoading}
+        error={modalError}
+        canvasRef={signatureRef}
+        onClear={handleClearSignature}
+        detail={detail}
+        detailLoading={detailLoading}
+        detailError={detailError}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/inspecoes/page.tsx
+++ b/src/app/admin/inspecoes/page.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  collection,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+} from "firebase/firestore";
+import { firebaseDb } from "@/lib/firebase-client";
+import { Button, buttonStyles } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { ChecklistAnswer } from "@/types";
+
+interface InspectionListItem {
+  id: string;
+  machineNome: string | null;
+  machineTag: string | null;
+  createdAt: string | null;
+  maintainerNome: string | null;
+  maintainerMatricula: string | null;
+  qtdNc: number;
+  hasNc: boolean;
+  osNumero: string | null;
+  signed: boolean;
+  signedAt: string | null;
+  pcmNome: string | null;
+}
+
+function formatDateTime(value: string | null) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleString("pt-BR");
+}
+
+export default function AdminInspectionsPage() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<InspectionListItem[]>([]);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const session = await fetch("/api/admin-session", { cache: "no-store" });
+      if (session.status === 401) {
+        window.location.href = "/admin/login";
+        setLoading(false);
+        return;
+      }
+
+      const inspectionsSnap = await getDocs(
+        query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"), limit(100))
+      );
+
+      const mapped: InspectionListItem[] = inspectionsSnap.docs.map(doc => {
+        const data = doc.data() ?? {};
+        const machine = (data.machine ?? {}) as Record<string, unknown>;
+        const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
+        const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+        const qtdNcFromAnswers = answers.filter(answer => answer?.response === "nc").length;
+        const qtdNc = typeof data.qtdNC === "number" ? data.qtdNC : qtdNcFromAnswers;
+        const pcmSign = (data.pcmSign ?? {}) as Record<string, unknown>;
+
+        return {
+          id: doc.id,
+          machineNome: machine.nome ? String(machine.nome) : null,
+          machineTag: machine.tag ? String(machine.tag) : null,
+          createdAt: data.createdAt ? String(data.createdAt) : null,
+          maintainerNome: maintainer.nome ? String(maintainer.nome) : null,
+          maintainerMatricula: maintainer.matricula ? String(maintainer.matricula) : null,
+          qtdNc,
+          hasNc: qtdNc > 0,
+          osNumero: data.osNumero ? String(data.osNumero) : null,
+          signed: Boolean(pcmSign && pcmSign.assinaturaUrl),
+          signedAt: pcmSign?.signedAt ? String(pcmSign.signedAt) : null,
+          pcmNome: pcmSign?.nome ? String(pcmSign.nome) : null,
+        } satisfies InspectionListItem;
+      });
+
+      setItems(mapped);
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Erro ao carregar inspeções";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("BroadcastChannel" in window)) {
+      return undefined;
+    }
+    const channel = new BroadcastChannel("pcm-inspecoes-events");
+    const handler = (event: MessageEvent) => {
+      const data = event.data as { type?: string; id?: string; nome?: string | null; signedAt?: string | null };
+      if (data?.type === "inspection-signed" && data.id) {
+        setItems(prev =>
+          prev.map(item =>
+            item.id === data.id
+              ? {
+                  ...item,
+                  signed: true,
+                  signedAt: data.signedAt ?? new Date().toISOString(),
+                  pcmNome: data.nome ?? item.pcmNome,
+                }
+              : item
+          )
+        );
+      }
+    };
+    channel.addEventListener("message", handler);
+    return () => {
+      channel.removeEventListener("message", handler);
+      channel.close();
+    };
+  }, []);
+
+  const signedCount = useMemo(() => items.filter(item => item.signed).length, [items]);
+  const pendingCount = useMemo(() => items.filter(item => !item.signed).length, [items]);
+  const withNcCount = useMemo(() => items.filter(item => item.hasNc).length, [items]);
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6 p-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-[var(--text)]">Inspeções</h1>
+        <p className="text-sm text-[var(--muted)]">
+          Centralize o acompanhamento das inspeções: acesse rapidamente assinaturas pendentes, edições e relatórios.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_85%)] px-4 py-3 text-[var(--danger)]">
+          {error}
+        </div>
+      ) : null}
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-lg text-[var(--text)]">Assinaturas pendentes</CardTitle>
+            <p className="text-sm text-[var(--muted)]">Priorize inspeções aguardando validação do PCM.</p>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-semibold text-[var(--text)]">{pendingCount}</span>
+              <Badge variant={pendingCount > 0 ? "danger" : "success"}>{pendingCount > 0 ? "Pendentes" : "Tudo assinado"}</Badge>
+            </div>
+            <Link href="/admin/inspecoes/assinar" className={buttonStyles({ size: "sm" })}>
+              Acessar assinaturas
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-lg text-[var(--text)]">Editar inspeções</CardTitle>
+            <p className="text-sm text-[var(--muted)]">Atualize respostas, fotos e encerramento de NCs quando necessário.</p>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-baseline gap-2">
+              <span className="text-2xl font-semibold text-[var(--text)]">{items.length}</span>
+              <Badge variant="muted">Registros</Badge>
+              {withNcCount > 0 ? <Badge variant="warning">{withNcCount} com NC</Badge> : null}
+            </div>
+            <Link href="#lista-inspecoes" className={buttonStyles({ size: "sm", variant: "secondary" })}>
+              Abrir lista para editar
+            </Link>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="space-y-1">
+            <CardTitle className="text-lg text-[var(--text)]">Visualizar inspeções</CardTitle>
+            <p className="text-sm text-[var(--muted)]">Consulte relatórios assinados e histórico completo.</p>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="flex items-baseline gap-2">
+              <span className="text-2xl font-semibold text-[var(--text)]">{signedCount}</span>
+              <Badge variant={signedCount > 0 ? "success" : "muted"}>{signedCount > 0 ? "Assinadas" : "Aguardando"}</Badge>
+            </div>
+            <Link href="#lista-inspecoes" className={buttonStyles({ size: "sm", variant: "ghost" })}>
+              Ver inspeções recentes
+            </Link>
+          </CardContent>
+        </Card>
+      </section>
+
+      <Card id="lista-inspecoes">
+        <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle className="text-lg text-[var(--text)]">Lista de inspeções</CardTitle>
+            <p className="text-sm text-[var(--muted)]">Visualize o status de assinatura e os acessos rápidos para cada inspeção.</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="secondary" onClick={loadData} disabled={loading}>
+              Recarregar
+            </Button>
+            <Link href="/admin/nc" className={buttonStyles({ size: "sm", variant: "ghost" })}>
+              Tratativas de NC
+            </Link>
+            <Badge variant="muted">Assinadas: {signedCount}</Badge>
+            <Badge variant={pendingCount > 0 ? "warning" : "muted"}>Pendentes: {pendingCount}</Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="space-y-3">
+              {[0, 1, 2, 3, 4].map(key => (
+                <div key={key} className="rounded-lg border border-[var(--border)] p-4">
+                  <Skeleton className="h-5 w-1/3" />
+                  <Skeleton className="mt-2 h-4 w-2/3" />
+                </div>
+              ))}
+            </div>
+          ) : items.length === 0 ? (
+            <EmptyState
+              title="Nenhuma inspeção encontrada"
+              description="As inspeções serão exibidas aqui assim que forem registradas."
+              className="py-12"
+            />
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Máquina</TableHead>
+                  <TableHead>Operador</TableHead>
+                  <TableHead>Data/Hora</TableHead>
+                  <TableHead>NC</TableHead>
+                  <TableHead>Assinatura PCM</TableHead>
+                  <TableHead className="text-right">Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map(item => (
+                  <TableRow key={item.id} className={item.hasNc ? "border-l-4 border-l-[var(--danger)]" : undefined}>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-medium text-[var(--text)]">{item.machineNome ?? "Máquina"}</span>
+                        <span className="text-xs text-[var(--muted)]">
+                          TAG {item.machineTag ?? "-"} • OS {item.osNumero ?? "-"}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="text-sm text-[var(--text)]">{item.maintainerNome ?? "-"}</span>
+                        <span className="text-xs text-[var(--muted)]">{item.maintainerMatricula ?? "-"}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell>{formatDateTime(item.createdAt)}</TableCell>
+                    <TableCell>
+                      {item.hasNc ? (
+                        <Badge variant="danger">{item.qtdNc} NC</Badge>
+                      ) : (
+                        <Badge variant="success">Sem NC</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {item.signed ? (
+                        <div className="flex flex-col gap-1">
+                          <Badge variant="success">Assinada</Badge>
+                          <span className="text-xs text-[var(--muted)]">
+                            {item.pcmNome ? `Por ${item.pcmNome}` : "Assistente"} • {formatDateTime(item.signedAt)}
+                          </span>
+                        </div>
+                      ) : (
+                        <Badge variant="warning">Pendente</Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex flex-wrap justify-end gap-2">
+                        {!item.signed ? (
+                          <Link
+                            href={`/admin/inspecoes/assinar?inspecao=${item.id}`}
+                            className={buttonStyles({ size: "sm" })}
+                          >
+                            Assinar
+                          </Link>
+                        ) : null}
+                        <Link
+                          href={`/admin/inspecoes/${item.id}/edit`}
+                          className={buttonStyles({ size: "sm", variant: "secondary" })}
+                        >
+                          Editar
+                        </Link>
+                        <a
+                          href={`/api/inspecoes/${item.id}/pdf`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className={buttonStyles({ size: "sm", variant: "ghost" })}
+                        >
+                          Ver PDF
+                        </a>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/mantenedores/page.tsx
+++ b/src/app/admin/mantenedores/page.tsx
@@ -1,6 +1,14 @@
 "use client";
-import { useEffect, useState } from "react";
+
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+
+import { buttonStyles } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 
 type Maintainer = {
   id: string;
@@ -17,10 +25,10 @@ export default function MantenedoresPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("/api/admin-session").then(r => {
+    fetch("/api/admin-session", { cache: "no-store" }).then(r => {
       if (r.status === 401) window.location.href = "/admin/login";
     });
-    fetch("/api/mantenedores").then(async r => {
+    fetch("/api/mantenedores", { cache: "no-store" }).then(async r => {
       if (r.ok) {
         const payload = (await r.json()) as Maintainer[];
         setData(payload);
@@ -29,161 +37,106 @@ export default function MantenedoresPage() {
     });
   }, []);
 
-  const filtered = data.filter(m =>
-    m.matricula.includes(q) || m.nome.toLowerCase().includes(q.toLowerCase())
+  const filtered = useMemo(
+    () => data.filter(m => m.matricula.includes(q) || m.nome.toLowerCase().includes(q.toLowerCase())),
+    [data, q]
   );
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4">
-      <div className="max-w-6xl mx-auto">
-        {/* Cabeçalho */}
-        <div className="flex flex-col md:flex-row md:items-center justify-between mb-8 pt-6">
-          <div className="flex items-center mb-4 md:mb-0">
-            <div className="w-12 h-12 rounded-full bg-green-600 flex items-center justify-center mr-3">
-              <i className="fas fa-tractor text-white text-xl"></i>
-            </div>
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900">Lar Cooperativa Agroindustrial</h1>
-              <p className="text-gray-600">Sistema de Manutenção de Rotas</p>
-            </div>
-          </div>
-          
-          <Link 
-            href="/admin/dashboard"
-            className="flex items-center justify-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white rounded-lg transition duration-150 ease-in-out"
-          >
-            <i className="fas fa-arrow-left mr-2"></i>
-            Voltar ao Dashboard
+    <div className="max-w-7xl mx-auto px-4 py-10 space-y-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold text-[var(--text)]">Mantenedores</h1>
+          <p className="text-sm text-[var(--muted)]">Administre os profissionais responsáveis pelas inspeções.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link href="/admin/dashboard" className={buttonStyles({ variant: "secondary" })}>
+            <i className="fas fa-arrow-left" aria-hidden />
+            Voltar ao dashboard
+          </Link>
+          <Link href="/admin/mantenedores/new" className={buttonStyles()}>
+            <i className="fas fa-plus" aria-hidden />
+            Novo mantenedor
           </Link>
         </div>
+      </header>
 
-        {/* Conteúdo Principal */}
-        <div className="bg-white rounded-2xl shadow-lg p-6 md:p-8">
-          <div className="flex flex-col md:flex-row md:items-center justify-between mb-8">
-            <div className="mb-4 md:mb-0">
-              <div className="flex items-center mb-2">
-                <div className="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center mr-3">
-                  <i className="fas fa-users-cog text-blue-600"></i>
-                </div>
-                <h2 className="text-2xl font-bold text-gray-900">Mantenedores</h2>
-              </div>
-              <p className="text-gray-600">Gerencie técnicos e mantenedores do sistema</p>
-            </div>
-            
-            <Link href="/admin/mantenedores/new">
-              <button className="flex items-center justify-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition duration-150 ease-in-out">
-                <i className="fas fa-plus mr-2"></i>
-                Novo Mantenedor
-              </button>
-            </Link>
+      <Card>
+        <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>Equipe cadastrada</CardTitle>
+            <CardDescription>Filtre por matrícula ou nome para localizar rapidamente um profissional.</CardDescription>
           </div>
-
-          {/* Barra de Busca */}
-          <div className="relative mb-6">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <i className="fas fa-search text-gray-400"></i>
-            </div>
-            <input
-              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition duration-150 ease-in-out"
-              placeholder="Buscar por matrícula ou nome..."
+          <div className="w-full sm:max-w-sm">
+            <Input
+              placeholder="Buscar por matrícula ou nome"
               value={q}
-              onChange={e => setQ(e.target.value)}
+              onChange={event => setQ(event.target.value)}
+              aria-label="Buscar mantenedor"
             />
           </div>
-
+        </CardHeader>
+        <CardContent>
           {loading ? (
-            <div className="text-center py-12">
-              <div className="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center mx-auto mb-4">
-                <i className="fas fa-spinner fa-spin text-blue-600 text-xl"></i>
-              </div>
-              <p className="text-gray-600">Carregando mantenedores...</p>
+            <div className="space-y-3">
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
+              <Skeleton className="h-12 w-full" />
             </div>
+          ) : filtered.length === 0 ? (
+            <EmptyState
+              title="Nenhum mantenedor encontrado"
+              description={
+                q
+                  ? "Ajuste os termos de busca para encontrar quem procura."
+                  : "Cadastre um mantenedor para gerenciar inspeções."
+              }
+              icon={<i className="fas fa-user-cog" aria-hidden />}
+            />
           ) : (
-            <div className="overflow-hidden rounded-lg border border-gray-200">
-              <table className="w-full">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Matrícula
-                    </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Nome
-                    </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Setor
-                    </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      LAC
-                    </th>
-                    <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Status
-                    </th>
-                    <th className="px-6 py-4 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Ações
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
-                  {filtered.map((m, index) => (
-                    <tr 
-                      key={m.id} 
-                      className={index % 2 === 0 ? 'bg-white' : 'bg-gray-50'}
-                    >
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm font-medium text-gray-900">{m.matricula}</div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-gray-900">{m.nome}</div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-gray-500">{m.setor}</div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-gray-500">{m.lac}</div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                          m.ativo 
-                            ? 'bg-green-100 text-green-800' 
-                            : 'bg-red-100 text-red-800'
-                        }`}>
-                          {m.ativo ? 'Ativo' : 'Inativo'}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                        <Link
-                          href={`/admin/mantenedores/${m.id}/machines`}
-                          className="inline-flex items-center px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-lg transition duration-150 ease-in-out"
-                        >
-                          <i className="fas fa-cogs mr-1"></i>
-                          Gerenciar Máquinas
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              
-              {filtered.length === 0 && (
-                <div className="text-center py-12">
-                  <div className="w-16 h-16 rounded-full bg-gray-100 flex items-center justify-center mx-auto mb-4">
-                    <i className="fas fa-users text-gray-400 text-xl"></i>
-                  </div>
-                  <p className="text-gray-500 mb-2">Nenhum mantenedor encontrado</p>
-                  <p className="text-gray-400 text-sm">
-                    {q ? 'Tente ajustar os termos da busca' : 'Cadastre o primeiro mantenedor'}
-                  </p>
-                </div>
-              )}
-            </div>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Matrícula</TableHead>
+                  <TableHead>Nome</TableHead>
+                  <TableHead>Setor</TableHead>
+                  <TableHead>LAC</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Ações</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map(m => (
+                  <TableRow key={m.id}>
+                    <TableCell className="font-medium">{m.matricula}</TableCell>
+                    <TableCell>{m.nome}</TableCell>
+                    <TableCell className="text-[var(--muted)]">{m.setor}</TableCell>
+                    <TableCell className="text-[var(--muted)]">{m.lac}</TableCell>
+                    <TableCell>
+                      <span
+                        className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${
+                          m.ativo ? "bg-emerald-100 text-emerald-700" : "bg-rose-100 text-rose-700"
+                        }`}
+                      >
+                        {m.ativo ? "Ativo" : "Inativo"}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Link
+                        href={`/admin/mantenedores/${m.id}/machines`}
+                        className={buttonStyles({ variant: "secondary", size: "sm" })}
+                      >
+                        <i className="fas fa-cogs" aria-hidden />
+                        Gerenciar máquinas
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
           )}
-        </div>
-
-        {/* Rodapé */}
-        <div className="text-center text-gray-500 text-sm mt-8 pb-4">
-          <p>Lar Cooperativa Agroindustrial &copy; {new Date().getFullYear()}</p>
-        </div>
-      </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Image from "next/image";
+import {
+  collection,
+  doc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  updateDoc,
+} from "firebase/firestore";
+import { firebaseDb } from "@/lib/firebase-client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Select } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import type {
+  ChecklistAnswer,
+  ChecklistNonConformityTreatment,
+  NonConformityStatus,
+} from "@/types";
+
+interface MachineOption {
+  id: string;
+  nome: string;
+  tag?: string | null;
+  ativo?: boolean;
+}
+
+interface TemplateItemData {
+  id?: string;
+  componente?: string;
+  criterio?: string;
+  oQueChecar?: string;
+}
+
+interface TemplateMeta {
+  nome?: string | null;
+  versao?: string | null;
+  itensMap: Map<string, TemplateItemData>;
+}
+
+interface NonConformityItem {
+  id: string;
+  responseId: string;
+  questionId: string;
+  machineId: string | null;
+  machineLabel: string;
+  machineTag: string | null;
+  templateId: string | null;
+  templateLabel: string;
+  templateVersion?: string | null;
+  questionText: string;
+  checklistDate: string | null;
+  operatorNome: string | null;
+  operatorMatricula: string | null;
+  observation: string | null;
+  photos: string[];
+  status: NonConformityStatus;
+  summary: string;
+  responsible: string;
+  dueDate: string;
+  dueDateIso: string | null;
+  recurrence: boolean;
+  updatedAt: string | null;
+}
+
+interface FeedbackState {
+  type: "success" | "error";
+  message: string;
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "-";
+  return date.toLocaleString("pt-BR");
+}
+
+function formatDateInput(value: string | null | undefined) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+}
+
+function normalizeAnswers(
+  data: Record<string, unknown>,
+  templateItems: Map<string, TemplateItemData>
+): ChecklistAnswer[] {
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length > 0) {
+    return answers
+      .filter(item => item?.questionId)
+      .map(item => ({
+        questionId: item.questionId,
+        questionText:
+          item.questionText ||
+          templateItems.get(item.questionId)?.oQueChecar ||
+          templateItems.get(item.questionId)?.criterio ||
+          templateItems.get(item.questionId)?.componente ||
+          `Item ${item.questionId}`,
+        response: item.response === "nc" || item.response === "na" ? item.response : "c",
+        observation: item.observation ?? null,
+        photoUrls: Array.isArray(item.photoUrls) ? item.photoUrls.filter(Boolean) : [],
+        recurrence: item.recurrence === true,
+      }));
+  }
+
+  const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  return itens
+    .filter(item => item?.templateItemId)
+    .map(item => {
+      const questionId = String(item.templateItemId);
+      const templateItem = templateItems.get(questionId) ?? {};
+      const resultado = String(item.resultado || "C").toLowerCase();
+      const response: "c" | "nc" | "na" = resultado === "nc" ? "nc" : resultado === "na" ? "na" : "c";
+      return {
+        questionId,
+        questionText:
+          templateItem.oQueChecar ||
+          templateItem.criterio ||
+          templateItem.componente ||
+          (typeof item.componente === "string" ? item.componente : `Item ${questionId}`),
+        response,
+        observation: typeof item.observacaoItem === "string" ? item.observacaoItem : null,
+        photoUrls: Array.isArray(item.fotos) ? item.fotos.filter(Boolean).map(String) : [],
+        recurrence: false,
+      } satisfies ChecklistAnswer;
+    });
+}
+
+function buildMachineLabel(machine: Record<string, unknown>) {
+  const nome = machine?.nome ? String(machine.nome) : "Máquina";
+  const tag = machine?.tag ? String(machine.tag) : null;
+  return tag ? `${nome} (${tag})` : nome;
+}
+
+function renderStatusBadge(status: NonConformityStatus) {
+  if (status === "resolved") return <Badge variant="success">Resolvida</Badge>;
+  if (status === "in_progress") return <Badge variant="warning">Em andamento</Badge>;
+  return <Badge variant="danger">Aberta</Badge>;
+}
+
+const STATUS_OPTIONS: Array<{ value: NonConformityStatus; label: string }> = [
+  { value: "open", label: "Aberta" },
+  { value: "in_progress", label: "Em andamento" },
+  { value: "resolved", label: "Resolvida" },
+];
+
+export default function AdminNonConformitiesPage() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<NonConformityItem[]>([]);
+  const [machines, setMachines] = useState<MachineOption[]>([]);
+  const [treatmentsByResponse, setTreatmentsByResponse] = useState<Record<string, ChecklistNonConformityTreatment[]>>({});
+  const [machineFilter, setMachineFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("pending");
+  const [savingId, setSavingId] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<Record<string, FeedbackState>>({});
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const session = await fetch("/api/admin-session", { cache: "no-store" });
+      if (session.status === 401) {
+        window.location.href = "/admin/login";
+        return;
+      }
+
+      const [machinesSnap, templatesSnap, responsesSnap] = await Promise.all([
+        getDocs(collection(firebaseDb, "maquinas")),
+        getDocs(collection(firebaseDb, "templates")),
+        getDocs(query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"), limit(200))),
+      ]);
+
+      const machineOptions: MachineOption[] = machinesSnap.docs.map(docSnap => {
+        const data = docSnap.data() ?? {};
+        return {
+          id: docSnap.id,
+          nome: typeof data.nome === "string" ? data.nome : docSnap.id,
+          tag: data.tag ? String(data.tag) : null,
+          ativo: data.ativo !== false,
+        } satisfies MachineOption;
+      });
+
+      const templateMap = new Map<string, TemplateMeta>();
+      templatesSnap.docs.forEach(docSnap => {
+        const data = docSnap.data() ?? {};
+        const itens = Array.isArray(data.itens) ? (data.itens as TemplateItemData[]) : [];
+        const itensMap = new Map<string, TemplateItemData>();
+        itens.forEach(item => {
+          if (item?.id) {
+            itensMap.set(String(item.id), item);
+          }
+        });
+        templateMap.set(docSnap.id, {
+          nome: data.nome ? String(data.nome) : docSnap.id,
+          versao: data.versao ? String(data.versao) : null,
+          itensMap,
+        });
+      });
+
+      const builtItems: NonConformityItem[] = [];
+      const treatmentsRecord: Record<string, ChecklistNonConformityTreatment[]> = {};
+
+      responsesSnap.docs.forEach(docSnap => {
+        const data = docSnap.data() ?? {};
+        const machine = (data.machine ?? {}) as Record<string, unknown>;
+        const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
+        const templateInfo = (data.template ?? {}) as Record<string, unknown>;
+        const templateId = templateInfo.id
+          ? String(templateInfo.id)
+          : machine.templateId
+          ? String(machine.templateId)
+          : null;
+        const templateMeta = templateId ? templateMap.get(templateId) : undefined;
+        const answers = normalizeAnswers(data, templateMeta?.itensMap ?? new Map());
+        const treatmentsArray = Array.isArray(data.nonConformityTreatments)
+          ? (data.nonConformityTreatments as ChecklistNonConformityTreatment[])
+          : [];
+
+        treatmentsRecord[docSnap.id] = treatmentsArray;
+        const treatmentMap = new Map<string, ChecklistNonConformityTreatment>();
+        treatmentsArray.forEach(treatment => {
+          if (treatment?.questionId) {
+            treatmentMap.set(treatment.questionId, treatment);
+          }
+        });
+
+        answers
+          .filter(answer => answer.response === "nc")
+          .forEach(answer => {
+            const treatment = treatmentMap.get(answer.questionId);
+            const dueDateIso = treatment?.dueDate ? String(treatment.dueDate) : null;
+            builtItems.push({
+              id: `${docSnap.id}:${answer.questionId}`,
+              responseId: docSnap.id,
+              questionId: answer.questionId,
+              machineId: machine.machineId ? String(machine.machineId) : machine.id ? String(machine.id) : null,
+              machineLabel: buildMachineLabel(machine),
+              machineTag: machine.tag ? String(machine.tag) : null,
+              templateId,
+              templateLabel: templateMeta?.nome ?? (templateInfo.nome ? String(templateInfo.nome) : "Template"),
+              templateVersion: templateMeta?.versao ?? (templateInfo.versao ? String(templateInfo.versao) : null),
+              questionText: answer.questionText ?? `Item ${answer.questionId}`,
+              checklistDate: data.createdAt ? String(data.createdAt) : data.finalizadaEm ? String(data.finalizadaEm) : null,
+              operatorNome: maintainer.nome ? String(maintainer.nome) : null,
+              operatorMatricula: maintainer.matricula ? String(maintainer.matricula) : null,
+              observation: answer.observation ?? null,
+              photos: Array.isArray(answer.photoUrls) ? answer.photoUrls.filter(Boolean) : [],
+              status: treatment?.status ?? "open",
+              summary: treatment?.summary ?? "",
+              responsible: treatment?.responsible ?? "",
+              dueDate: formatDateInput(dueDateIso),
+              dueDateIso,
+              recurrence: answer.recurrence ?? false,
+              updatedAt: treatment?.updatedAt ? String(treatment.updatedAt) : treatment?.createdAt ? String(treatment.createdAt) : null,
+            });
+          });
+      });
+
+      setMachines(machineOptions);
+      setItems(builtItems);
+      setTreatmentsByResponse(treatmentsRecord);
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Erro ao carregar dados";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const filteredItems = useMemo(() => {
+    return items.filter(item => {
+      if (machineFilter !== "all" && item.machineId !== machineFilter) {
+        return false;
+      }
+      if (statusFilter === "pending") {
+        return item.status !== "resolved";
+      }
+      if (statusFilter === "all") {
+        return true;
+      }
+      return item.status === statusFilter;
+    });
+  }, [items, machineFilter, statusFilter]);
+
+  const handleUpdateItem = useCallback((id: string, updates: Partial<NonConformityItem>) => {
+    setItems(prev => prev.map(item => (item.id === id ? { ...item, ...updates } : item)));
+  }, []);
+
+  const handleSave = useCallback(
+    async (item: NonConformityItem) => {
+      setSavingId(item.id);
+      setFeedback(prev => ({ ...prev, [item.id]: { type: "success", message: "" } }));
+      try {
+        const existing = treatmentsByResponse[item.responseId] ?? [];
+        const nowIso = new Date().toISOString();
+        const summary = item.summary.trim();
+        const responsible = item.responsible.trim();
+        const dueDateIso = item.dueDate ? new Date(`${item.dueDate}T00:00:00`).toISOString() : null;
+
+        const updatedTreatment: ChecklistNonConformityTreatment = {
+          questionId: item.questionId,
+          summary: summary || undefined,
+          responsible: responsible || undefined,
+          dueDate: dueDateIso,
+          status: item.status,
+          createdAt: existing.find(t => t.questionId === item.questionId)?.createdAt ?? nowIso,
+          updatedAt: nowIso,
+        };
+
+        const nextTreatments = [
+          ...existing.filter(t => t.questionId !== item.questionId),
+          updatedTreatment,
+        ];
+
+        await updateDoc(doc(collection(firebaseDb, "inspecoes"), item.responseId), {
+          nonConformityTreatments: nextTreatments,
+          updatedAt: nowIso,
+        });
+
+        setTreatmentsByResponse(prev => ({ ...prev, [item.responseId]: nextTreatments }));
+        handleUpdateItem(item.id, {
+          summary,
+          responsible,
+          dueDate: item.dueDate,
+          dueDateIso,
+          status: item.status,
+          updatedAt: nowIso,
+        });
+        setFeedback(prev => ({ ...prev, [item.id]: { type: "success", message: "Tratativa salva com sucesso" } }));
+      } catch (err: unknown) {
+        const message = err instanceof Error && err.message ? err.message : "Erro ao salvar tratativa";
+        setFeedback(prev => ({ ...prev, [item.id]: { type: "error", message } }));
+      } finally {
+        setSavingId(null);
+      }
+    },
+    [handleUpdateItem, treatmentsByResponse]
+  );
+
+  if (loading) {
+    return (
+      <div className="max-w-7xl mx-auto space-y-6 p-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-[var(--text)]">Não conformidades</h1>
+            <p className="text-sm text-[var(--muted)]">Visualize e trate as respostas marcadas como NC.</p>
+          </div>
+          <Button variant="secondary" disabled>
+            Recarregar
+          </Button>
+        </header>
+        {[0, 1, 2].map(key => (
+          <Card key={key}>
+            <CardHeader>
+              <Skeleton className="h-6 w-1/3" />
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-2/3" />
+              <Skeleton className="h-24 w-full" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto space-y-6 p-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-[var(--text)]">Não conformidades</h1>
+            <p className="text-sm text-[var(--muted)]">Visualize e trate as respostas marcadas como NC.</p>
+          </div>
+          <Button variant="secondary" onClick={() => loadData()}>
+            Recarregar
+          </Button>
+        </header>
+        <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_80%)] px-4 py-3 text-[var(--danger)]">
+          {error}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto space-y-6 p-6">
+      <header className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-[var(--text)]">Não conformidades</h1>
+          <p className="text-sm text-[var(--muted)]">Somente respostas &quot;NC&quot; aparecem nesta lista para tratativa.</p>
+        </div>
+        <Button variant="secondary" onClick={() => loadData()}>
+          Recarregar
+        </Button>
+      </header>
+
+      <Card>
+        <CardHeader className="pb-4">
+          <CardTitle className="text-base text-[var(--text)]">Filtros</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <label className="space-y-1 text-sm">
+            <span className="text-[var(--muted)]">Máquina</span>
+            <Select value={machineFilter} onChange={event => setMachineFilter(event.target.value)}>
+              <option value="all">Todas</option>
+              {machines
+                .filter(machine => machine.ativo !== false)
+                .map(machine => (
+                  <option key={machine.id} value={machine.id}>
+                    {machine.tag ? `${machine.nome} (${machine.tag})` : machine.nome}
+                  </option>
+                ))}
+            </Select>
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="text-[var(--muted)]">Status</span>
+            <Select value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
+              <option value="pending">Pendentes</option>
+              <option value="all">Todos</option>
+              <option value="open">Abertas</option>
+              <option value="in_progress">Em andamento</option>
+              <option value="resolved">Resolvidas</option>
+            </Select>
+          </label>
+        </CardContent>
+      </Card>
+
+      {filteredItems.length === 0 ? (
+        <EmptyState
+          title="Nenhuma não conformidade encontrada"
+          description="Ajuste os filtros ou aguarde novas inspeções com NC registradas."
+        />
+      ) : (
+        <div className="space-y-6">
+          {filteredItems.map(item => {
+            const itemFeedback = feedback[item.id];
+            return (
+              <article key={item.id}>
+                <Card>
+                  <CardHeader className="space-y-3">
+                    <div className="flex flex-wrap items-center gap-3">
+                      {renderStatusBadge(item.status)}
+                      {item.recurrence && <Badge variant="warning">Reincidência</Badge>}
+                      {item.templateVersion && <Badge variant="muted">Versão {item.templateVersion}</Badge>}
+                    </div>
+                    <div className="space-y-1">
+                      <CardTitle className="text-lg text-[var(--text)]">{item.questionText}</CardTitle>
+                      <p className="text-sm text-[var(--muted)]">
+                        Checklist em {formatDateTime(item.checklistDate)} — {item.templateLabel}
+                      </p>
+                    </div>
+                    <div className="grid gap-2 text-sm text-[var(--muted)] md:grid-cols-2">
+                      <div>
+                        <span className="font-medium text-[var(--text)]">Máquina:</span> {item.machineLabel}
+                      </div>
+                      <div>
+                        <span className="font-medium text-[var(--text)]">Operador:</span> {item.operatorNome || "-"}
+                        {item.operatorMatricula ? ` (${item.operatorMatricula})` : ""}
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent className="space-y-6">
+                    {item.observation && (
+                      <section className="space-y-2">
+                        <h3 className="text-sm font-semibold text-[var(--text)]">Observações do operador</h3>
+                        <p className="rounded-lg border border-[var(--border)] bg-white px-3 py-2 text-sm text-[var(--text)]">
+                          {item.observation}
+                        </p>
+                      </section>
+                    )}
+
+                    {item.photos.length > 0 && (
+                      <section className="space-y-2">
+                        <h3 className="text-sm font-semibold text-[var(--text)]">Fotos</h3>
+                        <div className="flex flex-wrap gap-3">
+                          {item.photos.map((photo, index) => (
+                            <div
+                              key={`${item.id}-photo-${index}`}
+                              className="overflow-hidden rounded-lg border border-[var(--border)] bg-white"
+                            >
+                              <Image
+                                src={photo}
+                                alt={`Foto da não conformidade ${index + 1}`}
+                                width={160}
+                                height={120}
+                                className="h-24 w-40 object-cover"
+                                unoptimized
+                              />
+                            </div>
+                          ))}
+                        </div>
+                      </section>
+                    )}
+
+                    <section className="space-y-3">
+                      <h3 className="text-sm font-semibold text-[var(--text)]">Tratativa planejada</h3>
+                      <Textarea
+                        value={item.summary}
+                        onChange={event => handleUpdateItem(item.id, { summary: event.target.value })}
+                        placeholder="Descreva a tratativa planejada"
+                      />
+                      <div className="grid gap-4 md:grid-cols-3">
+                        <label className="space-y-1 text-sm">
+                          <span className="text-[var(--muted)]">Responsável</span>
+                          <Input
+                            value={item.responsible}
+                            onChange={event => handleUpdateItem(item.id, { responsible: event.target.value })}
+                            placeholder="Nome do responsável"
+                          />
+                        </label>
+                        <label className="space-y-1 text-sm">
+                          <span className="text-[var(--muted)]">Prazo</span>
+                          <Input
+                            type="date"
+                            value={item.dueDate}
+                            onChange={event => handleUpdateItem(item.id, { dueDate: event.target.value })}
+                          />
+                        </label>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        {STATUS_OPTIONS.map(option => (
+                          <Button
+                            key={option.value}
+                            type="button"
+                            variant={item.status === option.value ? "default" : "outline"}
+                            onClick={() => handleUpdateItem(item.id, { status: option.value })}
+                          >
+                            {option.label}
+                          </Button>
+                        ))}
+                      </div>
+                    </section>
+
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="text-sm text-[var(--muted)]">
+                        {item.updatedAt ? `Atualizado em ${formatDateTime(item.updatedAt)}` : "Tratativa ainda não salva"}
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <Button onClick={() => handleSave(item)} loading={savingId === item.id}>
+                          Salvar tratativa
+                        </Button>
+                        {itemFeedback?.message && (
+                          <span
+                            className={
+                              itemFeedback.type === "success"
+                                ? "text-sm text-[var(--primary-700)]"
+                                : "text-sm text-[var(--danger)]"
+                            }
+                          >
+                            {itemFeedback.message}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/inspecoes/[id]/pcm-sign/route.ts
+++ b/src/app/api/inspecoes/[id]/pcm-sign/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { adminDb } from "@/lib/firebase-admin";
+import { requireAdminFromRequest } from "@/lib/guards";
+import { uploadToImgbbFromDataUrl } from "@/lib/imgbb";
+
+type RouteContext = { params: Promise<Record<string, string | string[] | undefined>> };
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const payloadSchema = z.object({
+  nome: z.string().trim().min(1),
+  cargo: z.string().trim().optional(),
+  assinaturaDataUrl: z.string().trim().min(1),
+});
+
+function resolveId(params: Record<string, string | string[] | undefined>) {
+  const idValue = params.id;
+  if (Array.isArray(idValue)) return idValue[0] ?? null;
+  return idValue ?? null;
+}
+
+export async function PATCH(req: NextRequest, context: RouteContext) {
+  const authorized = await requireAdminFromRequest(req);
+  if (!authorized) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  const params = (await context.params) ?? {};
+  const id = resolveId(params);
+  if (!id) {
+    return NextResponse.json({ error: "INVALID_ID" }, { status: 400 });
+  }
+
+  let payload: z.infer<typeof payloadSchema>;
+  try {
+    payload = payloadSchema.parse(await req.json());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "INVALID_PAYLOAD";
+    return NextResponse.json({ error: message }, { status: 422 });
+  }
+
+  try {
+    const docRef = adminDb.collection("inspecoes").doc(id);
+    const docSnap = await docRef.get();
+    if (!docSnap.exists) {
+      return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+    }
+
+    const upload = await uploadToImgbbFromDataUrl(payload.assinaturaDataUrl, `pcm-sign-${id}`);
+    const nowIso = new Date().toISOString();
+
+    await docRef.update({
+      pcmSign: {
+        nome: payload.nome,
+        cargo: payload.cargo ?? null,
+        assinaturaUrl: upload.url,
+        signedAt: nowIso,
+      },
+      updatedAt: nowIso,
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "INTERNAL_ERROR";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/inspecoes/[id]/route.ts
+++ b/src/app/api/inspecoes/[id]/route.ts
@@ -1,0 +1,436 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { adminDb } from "@/lib/firebase-admin";
+import { requireAdminFromRequest } from "@/lib/guards";
+import { uploadToImgbbFromDataUrl } from "@/lib/imgbb";
+import type {
+  ChecklistAnswer,
+  ChecklistNonConformityTreatment,
+  ChecklistResponse,
+  NonConformityStatus,
+} from "@/types";
+import type { QueryDocumentSnapshot, DocumentData } from "firebase-admin/firestore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = { params: Promise<Record<string, string | string[] | undefined>> };
+
+const itemPhotoSchema = z.union([
+  z.string().trim().min(1),
+  z.object({
+    dataUrl: z.string().trim().min(1),
+    name: z.string().trim().optional(),
+  }),
+]);
+
+const patchSchema = z.object({
+  osNumero: z.string().trim().optional(),
+  observacoes: z.string().trim().optional(),
+  assinaturaDataUrl: z.string().trim().optional(),
+  itens: z
+    .array(
+      z.object({
+        questionId: z.string().trim().min(1),
+        response: z.enum(["c", "nc", "na"]),
+        observation: z.string().trim().optional(),
+        photoUrls: z.array(itemPhotoSchema).max(5).optional(),
+      })
+    )
+    .optional(),
+});
+
+type PatchPayload = z.infer<typeof patchSchema>;
+
+type TemplateItem = {
+  id?: string;
+  componente?: string;
+  oQueChecar?: string;
+  instrumento?: string;
+  criterio?: string;
+  oQueFazer?: string;
+};
+
+function resolveId(params: Record<string, string | string[] | undefined>) {
+  const value = params.id;
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function normalizeAnswers(data: Record<string, unknown>, templateItemsMap: Map<string, TemplateItem>) {
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length > 0) {
+    return answers
+      .filter(item => item?.questionId)
+      .map(item => ({
+        questionId: item.questionId,
+        questionText:
+          item.questionText ?? templateItemsMap.get(item.questionId)?.oQueChecar ?? templateItemsMap.get(item.questionId)?.criterio ?? null,
+        response: item.response === "nc" || item.response === "na" ? item.response : "c",
+        observation: item.observation ?? null,
+        photoUrls: Array.isArray(item.photoUrls) ? item.photoUrls.filter(Boolean) : [],
+        recurrence: item.recurrence ?? false,
+      }));
+  }
+
+  const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  return itens
+    .filter(item => item?.templateItemId)
+    .map(item => {
+      const questionId = String(item.templateItemId);
+      const templateItem = templateItemsMap.get(questionId) ?? {};
+      const resultado = String(item.resultado || "C").toLowerCase();
+      const response: "c" | "nc" | "na" = resultado === "nc" ? "nc" : resultado === "na" ? "na" : "c";
+      return {
+        questionId,
+        questionText: templateItem.oQueChecar ?? templateItem.criterio ?? (typeof item.componente === "string" ? item.componente : null),
+        response,
+        observation: typeof item.observacaoItem === "string" ? item.observacaoItem : null,
+        photoUrls: Array.isArray(item.fotos) ? item.fotos.filter(Boolean).map(String) : [],
+        recurrence: false,
+      } satisfies ChecklistAnswer;
+    });
+}
+
+function mapTemplateItems(templateData: Record<string, unknown>) {
+  const items = Array.isArray(templateData.itens) ? (templateData.itens as TemplateItem[]) : [];
+  return new Map(items.filter(item => item?.id).map(item => [String(item.id), item]));
+}
+
+function ensureChecklistResponse(docId: string, data: Record<string, unknown>): ChecklistResponse {
+  return {
+    id: docId,
+    machine: (data.machine ?? null) as ChecklistResponse["machine"],
+    template: (data.template ?? null) as ChecklistResponse["template"],
+    maintainer: (data.maintainer ?? null) as ChecklistResponse["maintainer"],
+    answers: Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : undefined,
+    itens: data.itens,
+    nonConformityTreatments: Array.isArray(data.nonConformityTreatments)
+      ? (data.nonConformityTreatments as ChecklistNonConformityTreatment[])
+      : undefined,
+    observacoes: data.observacoes ? String(data.observacoes) : undefined,
+    osNumero: data.osNumero ? String(data.osNumero) : undefined,
+    assinaturaUrl: data.assinaturaUrl ? String(data.assinaturaUrl) : undefined,
+    pcmSign: (data.pcmSign ?? null) as ChecklistResponse["pcmSign"],
+    createdAt: data.createdAt ? String(data.createdAt) : undefined,
+    updatedAt: data.updatedAt ? String(data.updatedAt) : undefined,
+    iniciadaEm: data.iniciadaEm ? String(data.iniciadaEm) : undefined,
+    finalizadaEm: data.finalizadaEm ? String(data.finalizadaEm) : undefined,
+    qtdNC: typeof data.qtdNC === "number" ? data.qtdNC : undefined,
+  };
+}
+
+export async function GET(req: NextRequest, context: RouteContext) {
+  const authorized = await requireAdminFromRequest(req);
+  if (!authorized) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  const params = (await context.params) ?? {};
+  const id = resolveId(params);
+  if (!id) {
+    return NextResponse.json({ error: "INVALID_ID" }, { status: 400 });
+  }
+
+  try {
+    const docRef = adminDb.collection("inspecoes").doc(id);
+    const docSnap = await docRef.get();
+    if (!docSnap.exists) {
+      return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+    }
+
+    const data = docSnap.data() ?? {};
+    const inspection = ensureChecklistResponse(docSnap.id, data);
+
+    const templateId = inspection.template?.id || inspection.machine?.templateId || null;
+    let templateData: Record<string, unknown> | null = null;
+    if (templateId) {
+      const templateSnap = await adminDb.collection("templates").doc(String(templateId)).get();
+      if (templateSnap.exists) {
+        templateData = templateSnap.data() ?? null;
+      }
+    }
+
+    const templateItemsMap = templateData ? mapTemplateItems(templateData) : new Map<string, TemplateItem>();
+    const normalizedAnswers = normalizeAnswers(data, templateItemsMap);
+
+    return NextResponse.json({
+      inspection: {
+        ...inspection,
+        answers: normalizedAnswers,
+      },
+      template: templateData ? { id: templateId, ...(templateData ?? {}) } : null,
+      machine: inspection.machine ?? null,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "INTERNAL_ERROR";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest, context: RouteContext) {
+  const authorized = await requireAdminFromRequest(req);
+  if (!authorized) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  const params = (await context.params) ?? {};
+  const id = resolveId(params);
+  if (!id) {
+    return NextResponse.json({ error: "INVALID_ID" }, { status: 400 });
+  }
+
+  let payload: PatchPayload;
+  try {
+    payload = patchSchema.parse(await req.json());
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "INVALID_PAYLOAD";
+    return NextResponse.json({ error: message }, { status: 422 });
+  }
+
+  try {
+    const docRef = adminDb.collection("inspecoes").doc(id);
+    const docSnap = await docRef.get();
+    if (!docSnap.exists) {
+      return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+    }
+    const data = docSnap.data() ?? {};
+    const inspection = ensureChecklistResponse(docSnap.id, data);
+
+    const templateId = inspection.template?.id || inspection.machine?.templateId || null;
+    let templateData: Record<string, unknown> | null = null;
+    if (templateId) {
+      const templateSnap = await adminDb.collection("templates").doc(String(templateId)).get();
+      if (templateSnap.exists) {
+        templateData = templateSnap.data() ?? null;
+      }
+    }
+    const templateItemsMap = templateData ? mapTemplateItems(templateData) : new Map<string, TemplateItem>();
+
+    const currentAnswers = normalizeAnswers(data, templateItemsMap);
+
+    const currentTreatmentsArray = Array.isArray(inspection.nonConformityTreatments)
+      ? (inspection.nonConformityTreatments as ChecklistNonConformityTreatment[])
+      : [];
+    const treatmentsMap = new Map(currentTreatmentsArray.map(item => [item.questionId, item]));
+
+    const nowIso = new Date().toISOString();
+
+    const updates: Record<string, unknown> = {};
+
+    if (typeof payload.osNumero !== "undefined") {
+      updates.osNumero = payload.osNumero.trim() ? payload.osNumero.trim() : null;
+    }
+    if (typeof payload.observacoes !== "undefined") {
+      updates.observacoes = payload.observacoes.trim() ? payload.observacoes.trim() : null;
+    }
+
+    if (payload.assinaturaDataUrl) {
+      const upload = await uploadToImgbbFromDataUrl(payload.assinaturaDataUrl, `pcm-sign-${id}`);
+      updates.pcmSign = {
+        ...(inspection.pcmSign ?? {}),
+        assinaturaUrl: upload.url,
+        signedAt: nowIso,
+      };
+    }
+
+    const openIssuesSnap = inspection.machine?.machineId
+      ? await adminDb
+          .collection("issues")
+          .where("machineId", "==", inspection.machine.machineId)
+          .where("status", "==", "aberta")
+          .get()
+      : null;
+
+    const openIssuesMap = new Map<string, QueryDocumentSnapshot<DocumentData>>();
+    if (openIssuesSnap) {
+      openIssuesSnap.docs.forEach(doc => {
+        const issueData = doc.data() ?? {};
+        if (issueData.templateItemId) {
+          openIssuesMap.set(String(issueData.templateItemId), doc);
+        }
+      });
+    }
+
+    const answersToPersist: ChecklistAnswer[] = currentAnswers.map(answer => ({
+      questionId: answer.questionId,
+      questionText: answer.questionText ?? null,
+      response: answer.response === "nc" ? "nc" : answer.response === "na" ? "na" : "c",
+      observation: answer.observation ?? null,
+      photoUrls: Array.isArray(answer.photoUrls) ? answer.photoUrls.filter(Boolean) : [],
+      recurrence: answer.recurrence ?? false,
+    }));
+    const answersPersistMap = new Map(answersToPersist.map(answer => [answer.questionId, answer]));
+    const itensToPersist: Array<Record<string, unknown>> = Array.isArray(data.itens)
+      ? (data.itens as Array<Record<string, unknown>>).map(item => ({ ...item }))
+      : [];
+
+    const itensMap = new Map<string, Record<string, unknown>>();
+    itensToPersist.forEach(item => {
+      if (item.templateItemId) {
+        itensMap.set(String(item.templateItemId), item);
+      }
+    });
+
+    const issuesCriadas = Array.isArray(data.issuesCriadas) ? [...(data.issuesCriadas as string[])] : [];
+    const issuesResolvidas = Array.isArray(data.issuesResolvidas) ? [...(data.issuesResolvidas as string[])] : [];
+
+    const osNumeroValue =
+      typeof updates.osNumero !== "undefined"
+        ? (updates.osNumero as string | null)
+        : inspection.osNumero ?? null;
+
+    if (payload.itens) {
+      for (const item of payload.itens) {
+        const templateItem = templateItemsMap.get(item.questionId) ?? null;
+        if (templateItemsMap.size > 0 && !templateItem) {
+          continue;
+        }
+        const existingAnswer = answersPersistMap.get(item.questionId);
+        if (existingAnswer && !existingAnswer.questionText && templateItem) {
+          existingAnswer.questionText = templateItem.oQueChecar ?? templateItem.criterio ?? existingAnswer.questionText ?? null;
+        }
+        const response = item.response;
+
+        const photoUrls: string[] = [];
+        if (Array.isArray(item.photoUrls)) {
+          for (const photo of item.photoUrls) {
+            if (typeof photo === "string") {
+              photoUrls.push(photo);
+            } else if (photo?.dataUrl) {
+              const upload = await uploadToImgbbFromDataUrl(photo.dataUrl, `${id}-${item.questionId}-${photo.name ?? "foto"}`);
+              photoUrls.push(upload.url);
+            }
+          }
+        } else if (existingAnswer?.photoUrls) {
+          photoUrls.push(...existingAnswer.photoUrls);
+        }
+
+        const observation = item.observation?.trim() ? item.observation.trim() : null;
+
+        if (existingAnswer) {
+          existingAnswer.response = response;
+          existingAnswer.observation = observation;
+          if (photoUrls.length > 0 || item.photoUrls) {
+            existingAnswer.photoUrls = photoUrls;
+          }
+        } else {
+          const created = {
+            questionId: item.questionId,
+            questionText: templateItem?.oQueChecar ?? templateItem?.criterio ?? null,
+            response,
+            observation,
+            photoUrls,
+          } satisfies ChecklistAnswer;
+          answersToPersist.push(created);
+          answersPersistMap.set(item.questionId, created);
+        }
+
+        const existingItemEntry = itensMap.get(item.questionId);
+        if (existingItemEntry) {
+          existingItemEntry.resultado = response.toUpperCase();
+          existingItemEntry.observacaoItem = observation;
+          if (photoUrls.length > 0 || item.photoUrls) {
+            existingItemEntry.fotos = photoUrls;
+          }
+        } else {
+          itensToPersist.push({
+            templateItemId: item.questionId,
+            resultado: response.toUpperCase(),
+            observacaoItem: observation,
+            fotos: photoUrls,
+          });
+        }
+
+        const existingTreatment = treatmentsMap.get(item.questionId);
+        if (response === "nc") {
+          const updatedTreatment = existingTreatment
+            ? {
+                ...existingTreatment,
+                status: existingTreatment.status === "resolved" ? "open" : existingTreatment.status,
+                updatedAt: nowIso,
+              }
+            : {
+                questionId: item.questionId,
+                status: "open" as NonConformityStatus,
+                createdAt: nowIso,
+              };
+          treatmentsMap.set(item.questionId, updatedTreatment);
+
+          if (openIssuesMap.has(item.questionId)) {
+            const issueDoc = openIssuesMap.get(item.questionId)!;
+            if (osNumeroValue && issueDoc.data()?.osNumero !== osNumeroValue) {
+              await issueDoc.ref.update({ osNumero: osNumeroValue });
+            }
+          } else if (inspection.machine?.machineId) {
+            const issueRef = adminDb.collection("issues").doc();
+            await issueRef.set({
+              machineId: inspection.machine.machineId,
+              tag: inspection.machine.tag ?? null,
+              templateItemId: item.questionId,
+              descricao:
+                observation ||
+                templateItem?.criterio ||
+                templateItem?.oQueChecar ||
+                "NC registrada na edição da inspeção",
+              osNumero: osNumeroValue,
+              status: "aberta",
+              abertaEmInspecaoId: id,
+              createdAt: nowIso,
+            });
+            issuesCriadas.push(issueRef.id);
+          }
+        } else {
+          if (existingTreatment) {
+            treatmentsMap.set(item.questionId, {
+              ...existingTreatment,
+              status: "resolved",
+              updatedAt: nowIso,
+            });
+          }
+          const issueDoc = openIssuesMap.get(item.questionId);
+          if (issueDoc) {
+            await issueDoc.ref.update({
+              status: "resolvida",
+              resolvedAt: nowIso,
+              resolvidaEmInspecaoId: id,
+            });
+            if (!issuesResolvidas.includes(issueDoc.id)) {
+              issuesResolvidas.push(issueDoc.id);
+            }
+            openIssuesMap.delete(item.questionId);
+          }
+        }
+      }
+    }
+
+    const treatmentsArray = Array.from(treatmentsMap.values());
+
+    const finalAnswers = answersToPersist.map(answer => ({
+      ...answer,
+      response: answer.response === "nc" || answer.response === "na" ? answer.response : "c",
+      photoUrls: Array.isArray(answer.photoUrls) ? answer.photoUrls.filter(Boolean) : [],
+    }));
+
+    const qtdNC = finalAnswers.filter(answer => answer.response === "nc").length;
+
+    updates.answers = finalAnswers;
+    updates.itens = itensToPersist.map(item => ({
+      ...item,
+      resultado: typeof item.resultado === "string" ? item.resultado : "C",
+      fotos: Array.isArray(item.fotos) ? item.fotos : [],
+    }));
+    updates.nonConformityTreatments = treatmentsArray;
+    updates.qtdNC = qtdNC;
+    updates.updatedAt = nowIso;
+    updates.issuesCriadas = issuesCriadas;
+    updates.issuesResolvidas = issuesResolvidas;
+
+    await docRef.update(updates);
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "INTERNAL_ERROR";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/inspecoes/pending-sign/route.ts
+++ b/src/app/api/inspecoes/pending-sign/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server";
+import { adminDb } from "@/lib/firebase-admin";
+import { requireAdminFromRequest } from "@/lib/guards";
+import type { ChecklistAnswer } from "@/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type ResponseItem = {
+  id: string;
+  machineId: string | null;
+  templateId: string | null;
+  createdAt: string | null;
+  operatorNome: string | null;
+  operatorMatricula: string | null;
+  hasNC: boolean;
+  qtdNC: number;
+  machineTag: string | null;
+  machineNome: string | null;
+};
+
+function normalizeAnswers(data: Record<string, unknown>): ChecklistAnswer[] {
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length > 0) {
+    return answers
+      .filter(item => item?.questionId)
+      .map(item => ({
+        ...item,
+        response: item.response === "nc" || item.response === "c" || item.response === "na" ? item.response : "c",
+        photoUrls: Array.isArray(item.photoUrls) ? item.photoUrls.filter(Boolean) : [],
+      }));
+  }
+
+  const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  return itens
+    .filter(item => item?.templateItemId)
+    .map(item => ({
+      questionId: String(item.templateItemId),
+      questionText: typeof item.componente === "string" ? item.componente : undefined,
+      response: String(item.resultado || "C").toLowerCase() === "nc" ? "nc" : String(item.resultado || "C").toLowerCase() === "na" ? "na" : "c",
+      observation: typeof item.observacaoItem === "string" ? item.observacaoItem : undefined,
+      photoUrls: Array.isArray(item.fotos) ? item.fotos.filter(Boolean).map(String) : [],
+    }));
+}
+
+export async function GET(req: NextRequest) {
+  const authorized = await requireAdminFromRequest(req);
+  if (!authorized) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  try {
+    const snapshot = await adminDb
+      .collection("inspecoes")
+      .orderBy("createdAt", "desc")
+      .limit(300)
+      .get();
+
+    const items: ResponseItem[] = [];
+
+    snapshot.docs.forEach(doc => {
+      const data = doc.data() ?? {};
+      if (data.pcmSign) return;
+      const answers = normalizeAnswers(data);
+      const ncAnswers = answers.filter(answer => answer.response === "nc");
+      const machine = (data.machine ?? {}) as Record<string, unknown>;
+      const template = (data.template ?? {}) as Record<string, unknown>;
+      const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
+
+      items.push({
+        id: doc.id,
+        machineId: machine.machineId ? String(machine.machineId) : null,
+        templateId: template.id ? String(template.id) : machine.templateId ? String(machine.templateId) : null,
+        createdAt: data.createdAt ? String(data.createdAt) : null,
+        operatorNome: maintainer.nome ? String(maintainer.nome) : null,
+        operatorMatricula: maintainer.matricula ? String(maintainer.matricula) : null,
+        hasNC: ncAnswers.length > 0,
+        qtdNC: ncAnswers.length,
+        machineTag: machine.tag ? String(machine.tag) : null,
+        machineNome: machine.nome ? String(machine.nome) : null,
+      });
+    });
+
+    return NextResponse.json(items);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "INTERNAL_ERROR";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,17 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f4f7fb;
+  --foreground: #111827;
+  --primary: #2563eb;
+  --primary-700: #1d4ed8;
+  --surface: #ffffff;
+  --surface-strong: #f1f5f9;
+  --border: #e2e8f0;
+  --text: #111827;
+  --muted: #6b7280;
+  --hint: #9ca3af;
+  --danger: #dc2626;
   --font-geist-sans: Arial, Helvetica, sans-serif;
   --font-geist-mono: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
@@ -16,13 +25,30 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #0f172a;
+    --foreground: #e2e8f0;
+    --surface: #111827;
+    --surface-strong: #1f2937;
+    --border: #1f2937;
+    --text: #e2e8f0;
+    --muted: #94a3b8;
+    --hint: #cbd5f5;
+    --primary: #3b82f6;
+    --primary-700: #1d4ed8;
+    --danger: #f87171;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans);
+}
+
+a {
+  color: inherit;
+}
+
+button, input, select, textarea {
+  font: inherit;
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,29 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+type BadgeVariant = "default" | "success" | "warning" | "danger" | "muted";
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: BadgeVariant;
+}
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default: "bg-[var(--surface-strong)] text-[var(--text)] border border-[var(--border)]",
+  success: "bg-[color-mix(in_oklab,var(--primary),#fff_70%)] text-[var(--primary-700)]",
+  warning: "bg-[color-mix(in_oklab,#fbbf24,#fff_70%)] text-[#b45309]",
+  danger: "bg-[color-mix(in_oklab,var(--danger),#fff_70%)] text-[#991b1b]",
+  muted: "bg-[var(--surface)] text-[var(--muted)] border border-[var(--border)]",
+};
+
+export function Badge({ className, variant = "default", ...props }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold uppercase tracking-wide",
+        variantClasses[variant],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,83 @@
+import { forwardRef } from "react";
+import type { ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+type ButtonVariant = "default" | "outline" | "ghost" | "secondary" | "destructive";
+type ButtonSize = "sm" | "md" | "lg" | "icon";
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  default:
+    "bg-[var(--primary)] text-white hover:bg-[var(--primary-700)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]",
+  outline:
+    "border border-[var(--border)] text-[var(--text)] hover:bg-[var(--surface)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]",
+  ghost:
+    "text-[var(--text)] hover:bg-[var(--surface)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]",
+  secondary:
+    "bg-[var(--surface)] text-[var(--text)] hover:bg-[color-mix(in_oklab,var(--surface),#000_5%)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]",
+  destructive:
+    "bg-[var(--danger)] text-white hover:bg-[color-mix(in_oklab,var(--danger),#000_8%)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--danger)]",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "h-9 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-11 px-6 text-base",
+  icon: "h-10 w-10",
+};
+
+interface ButtonStyleOptions {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+}
+
+export function buttonStyles({ variant = "default", size = "md", className }: ButtonStyleOptions = {}) {
+  return cn(
+    "inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60",
+    variantClasses[variant],
+    sizeClasses[size],
+    className
+  );
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "md", disabled, loading, children, ...props }, ref) => {
+    const isDisabled = disabled || loading;
+    return (
+      <button
+        ref={ref}
+        className={buttonStyles({ variant, size, className })}
+        disabled={isDisabled}
+        {...props}
+      >
+        {loading && (
+          <svg
+            className="h-4 w-4 animate-spin"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            role="presentation"
+          >
+            <circle className="opacity-20" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+            <path
+              className="opacity-80"
+              d="M4 12a8 8 0 0 1 8-8"
+              stroke="currentColor"
+              strokeWidth="4"
+              strokeLinecap="round"
+              fill="none"
+            />
+          </svg>
+        )}
+        <span>{children}</span>
+      </button>
+    );
+  }
+);
+
+Button.displayName = "Button";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,58 @@
+import type { HTMLAttributes } from "react";
+import { forwardRef } from "react";
+import { cn } from "@/lib/cn";
+
+export type CardProps = HTMLAttributes<HTMLDivElement>;
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border border-[var(--border)] bg-[var(--surface)] text-[var(--text)] shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+
+Card.displayName = "Card";
+
+export const CardHeader = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pb-0", className)} {...props} />
+  )
+);
+
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = forwardRef<HTMLHeadingElement, HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn("text-lg font-semibold", className)} {...props} />
+  )
+);
+
+CardTitle.displayName = "CardTitle";
+
+export const CardDescription = forwardRef<HTMLParagraphElement, HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-[var(--muted)]", className)} {...props} />
+  )
+);
+
+CardDescription.displayName = "CardDescription";
+
+export const CardContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  )
+);
+
+CardContent.displayName = "CardContent";
+
+export const CardFooter = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("flex items-center gap-3 p-6 pt-0", className)} {...props} />
+  )
+);
+
+CardFooter.displayName = "CardFooter";

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,68 @@
+import { createPortal } from "react-dom";
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Button } from "./button";
+import { cn } from "@/lib/cn";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm(): void;
+  onCancel(): void;
+  busy?: boolean;
+  footer?: ReactNode;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirmar",
+  cancelLabel = "Cancelar",
+  onConfirm,
+  onCancel,
+  busy,
+  footer,
+}: ConfirmDialogProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  if (!mounted) return null;
+  const portalTarget = document.body;
+  if (!portalTarget || !open) return null;
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+    >
+      <div className={cn("w-full max-w-md rounded-xl bg-white p-6 shadow-xl")}>
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold text-[var(--text)]">{title}</h2>
+          {description && <p className="text-sm text-[var(--muted)]">{description}</p>}
+        </div>
+        {footer ? (
+          <div className="mt-6">{footer}</div>
+        ) : (
+          <div className="mt-6 flex justify-end gap-3">
+            <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+              {cancelLabel}
+            </Button>
+            <Button type="button" variant="destructive" onClick={onConfirm} loading={busy}>
+              {confirmLabel}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>,
+    portalTarget
+  );
+}

--- a/src/components/ui/empty-state.tsx
+++ b/src/components/ui/empty-state.tsx
@@ -1,0 +1,24 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description?: string;
+  icon?: ReactNode;
+}
+
+export function EmptyState({ title, description, icon, className, ...props }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-[var(--border)] bg-[var(--surface)] px-6 py-12 text-center text-[var(--muted)]",
+        className
+      )}
+      {...props}
+    >
+      {icon && <div className="text-3xl" aria-hidden>{icon}</div>}
+      <h3 className="text-base font-semibold text-[var(--text)]">{title}</h3>
+      {description && <p className="max-w-md text-sm text-[var(--muted)]">{description}</p>}
+    </div>
+  );
+}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import { forwardRef } from "react";
+import type { InputHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-[var(--border)] bg-white px-3 py-2 text-sm text-[var(--text)] shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60",
+      className
+    )}
+    {...props}
+  />
+));
+
+Input.displayName = "Input";

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,20 @@
+import { forwardRef } from "react";
+import type { SelectHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(({ className, children, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full appearance-none rounded-md border border-[var(--border)] bg-white px-3 py-2 text-sm text-[var(--text)] shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </select>
+));
+
+Select.displayName = "Select";

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,11 @@
+import { cn } from "@/lib/cn";
+import type { HTMLAttributes } from "react";
+
+export function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-[var(--surface-strong)]", className)}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,64 @@
+import type { HTMLAttributes, TableHTMLAttributes } from "react";
+import { forwardRef } from "react";
+import { cn } from "@/lib/cn";
+
+export const Table = forwardRef<HTMLTableElement, TableHTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-x-auto">
+      <table
+        ref={ref}
+        className={cn(
+          "w-full min-w-[640px] border-collapse text-left text-sm text-[var(--text)]",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+);
+
+Table.displayName = "Table";
+
+export const TableHeader = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead
+      ref={ref}
+      className={cn("bg-[var(--surface-strong)] text-xs uppercase tracking-wide text-[var(--muted)]", className)}
+      {...props}
+    />
+  )
+);
+
+TableHeader.displayName = "TableHeader";
+
+export const TableHead = forwardRef<HTMLTableCellElement, HTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th ref={ref} className={cn("px-4 py-3 font-semibold", className)} scope="col" {...props} />
+  )
+);
+
+TableHead.displayName = "TableHead";
+
+export const TableBody = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn("divide-y divide-[var(--border)]", className)} {...props} />
+  )
+);
+
+TableBody.displayName = "TableBody";
+
+export const TableRow = forwardRef<HTMLTableRowElement, HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr ref={ref} className={cn("transition hover:bg-[var(--surface)]", className)} {...props} />
+  )
+);
+
+TableRow.displayName = "TableRow";
+
+export const TableCell = forwardRef<HTMLTableCellElement, HTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td ref={ref} className={cn("px-4 py-3 align-top", className)} {...props} />
+  )
+);
+
+TableCell.displayName = "TableCell";

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import { forwardRef } from "react";
+import type { TextareaHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      "flex min-h-[120px] w-full rounded-md border border-[var(--border)] bg-white px-3 py-2 text-sm text-[var(--text)] shadow-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)] disabled:cursor-not-allowed disabled:opacity-60",
+      className
+    )}
+    {...props}
+  />
+));
+
+Textarea.displayName = "Textarea";

--- a/src/lib/cn.ts
+++ b/src/lib/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}

--- a/src/lib/imgbb.ts
+++ b/src/lib/imgbb.ts
@@ -43,15 +43,18 @@ export async function uploadToImgbbFromDataUrl(
   expirationSec?: number
 ): Promise<{ url: string; display_url: string; delete_url?: string }> {
   const base64 = extractBase64(dataUrl);
-  const form = new FormData();
-  form.set("image", base64);
+  const body = new URLSearchParams();
+  body.set("image", base64);
   if (name && name.trim()) {
-    form.set("name", name.trim());
+    body.set("name", name.trim());
   }
 
   const response = await fetch(buildEndpoint(expirationSec), {
     method: "POST",
-    body: form,
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body,
   });
 
   let payload: UploadResponse | null = null;

--- a/src/server/pdf/header-lar.ts
+++ b/src/server/pdf/header-lar.ts
@@ -1,0 +1,218 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { jsPDF } from "jspdf";
+
+export type LarHeaderData = {
+  tituloTemplate: string;
+  unidade: string;
+  setor: string;
+  dataInspecaoISO: string;
+  maquinaNome: string;
+  tag: string;
+  fotoMaquinaUrl?: string;
+};
+
+type ParsedImage = { data: string; format: "PNG" | "JPEG" | "WEBP" };
+
+let cachedLarLogo: ParsedImage | null | undefined;
+
+function loadLarLogo(): ParsedImage | null {
+  if (cachedLarLogo !== undefined) {
+    return cachedLarLogo;
+  }
+
+  try {
+    const logoPath = join(process.cwd(), "public", "lar-logo.png");
+    const buffer = readFileSync(logoPath);
+    cachedLarLogo = {
+      data: buffer.toString("base64"),
+      format: "PNG",
+    };
+    return cachedLarLogo;
+  } catch {
+    cachedLarLogo = null;
+    return null;
+  }
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return "-";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "-";
+  }
+  return date.toLocaleDateString("pt-BR");
+}
+
+function parseImageSource(src?: string | null): ParsedImage | null {
+  if (!src) return null;
+  if (!src.startsWith("data:")) {
+    return null;
+  }
+
+  const match = /^data:image\/(png|jpeg|jpg|webp);base64,(.+)$/i.exec(src);
+  if (!match) {
+    return null;
+  }
+
+  const [, subtype, base64] = match;
+  const format = subtype.toLowerCase() === "png" ? "PNG" : subtype.toLowerCase() === "webp" ? "WEBP" : "JPEG";
+  return { data: base64, format };
+}
+
+function drawInfoCell(
+  doc: jsPDF,
+  text: string,
+  x: number,
+  y: number,
+  options: { bold?: boolean; size?: number }
+) {
+  const { bold = false, size = 9 } = options;
+  doc.setFont("helvetica", bold ? "bold" : "normal");
+  doc.setFontSize(size);
+  doc.text(text, x, y);
+}
+
+export function drawLarHeader(
+  doc: jsPDF,
+  data: LarHeaderData,
+  opts?: { pageWidthMm?: number }
+): { headerHeightMm: number } {
+  const pageWidth = opts?.pageWidthMm ?? doc.internal.pageSize.getWidth();
+  const margin = 10;
+  const top = margin;
+  const contentWidth = pageWidth - margin * 2;
+  const innerPadding = 2;
+  const innerLeft = margin + innerPadding;
+  const innerTop = top + innerPadding;
+
+  const templateTitle = data.tituloTemplate?.trim() || "INSPEÇÃO";
+  const titleUpper = templateTitle.toUpperCase();
+
+  const infoTableWidth = 64;
+  const infoTableHeight = 24;
+  const infoTableX = margin + contentWidth - innerPadding - infoTableWidth;
+  const infoTableY = innerTop;
+
+  const logoBox = {
+    x: innerLeft,
+    y: innerTop,
+    w: 22,
+    h: 22,
+  };
+
+  const titleAreaX = logoBox.x + logoBox.w + 6;
+  const titleAreaRight = infoTableX - 4;
+  const titleAreaWidth = Math.max(titleAreaRight - titleAreaX, 40);
+
+  doc.setDrawColor(0);
+  doc.setLineWidth(0.4);
+
+  const logoImage = loadLarLogo();
+  if (logoImage) {
+    doc.addImage(logoImage.data, logoImage.format, logoBox.x, logoBox.y, logoBox.w, logoBox.h);
+  } else {
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(18);
+    doc.text("Lar", logoBox.x + 2, logoBox.y + logoBox.h / 1.5);
+  }
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(13);
+  doc.text(
+    `INSPEÇÃO ${titleUpper}`,
+    titleAreaX + titleAreaWidth / 2,
+    innerTop + 10,
+    { align: "center" }
+  );
+
+  doc.setFontSize(12);
+  doc.text(titleUpper, titleAreaX + titleAreaWidth / 2, innerTop + 18, { align: "center" });
+
+  doc.rect(infoTableX, infoTableY, infoTableWidth, infoTableHeight);
+  const rowHeight = infoTableHeight / 3;
+  const colSplit = infoTableX + infoTableWidth / 2;
+  doc.line(infoTableX, infoTableY + rowHeight, infoTableX + infoTableWidth, infoTableY + rowHeight);
+  doc.line(infoTableX, infoTableY + rowHeight * 2, infoTableX + infoTableWidth, infoTableY + rowHeight * 2);
+  doc.line(colSplit, infoTableY, colSplit, infoTableY + infoTableHeight);
+
+  drawInfoCell(doc, "NÚMERO:", infoTableX + 2, infoTableY + 5, { bold: true, size: 8.5 });
+  drawInfoCell(doc, "PÁGINAS:", colSplit + 2, infoTableY + 5, { bold: true, size: 8.5 });
+
+  drawInfoCell(doc, "FO 012 050 33", infoTableX + 2, infoTableY + rowHeight + 5, { bold: true, size: 10 });
+  drawInfoCell(doc, "1/1", colSplit + 2, infoTableY + rowHeight + 5, { bold: true, size: 10 });
+
+  drawInfoCell(doc, "EMISSÃO:  REVISÃO:  Nº", infoTableX + 2, infoTableY + rowHeight * 2 + 5, {
+    bold: true,
+    size: 8.5,
+  });
+  drawInfoCell(doc, "08/04/2024  05/07/2024  01", colSplit + 2, infoTableY + rowHeight * 2 + 5, {
+    bold: true,
+    size: 9.5,
+  });
+
+  const photoBoxWidth = 105;
+  const photoBoxHeight = 35;
+  const photoBoxX = margin + contentWidth - innerPadding - photoBoxWidth;
+  const infoSectionWidth = Math.max(photoBoxX - innerLeft - 4, 60);
+
+  const infoRowY = infoTableY + infoTableHeight + 8;
+  const infoRowHeight = 10;
+  const infoRowWidth = infoSectionWidth;
+  doc.rect(innerLeft, infoRowY, infoRowWidth, infoRowHeight);
+  const colWidth = infoRowWidth / 3;
+  doc.line(innerLeft + colWidth, infoRowY, innerLeft + colWidth, infoRowY + infoRowHeight);
+  doc.line(innerLeft + colWidth * 2, infoRowY, innerLeft + colWidth * 2, infoRowY + infoRowHeight);
+
+  const unidade = data.unidade?.trim() || "-";
+  const setor = data.setor?.trim() || "-";
+  const dataInspecao = formatDate(data.dataInspecaoISO);
+
+  drawInfoCell(doc, `Unidade: ${unidade}`, innerLeft + 2, infoRowY + 6, { bold: false, size: 9 });
+  drawInfoCell(doc, `Setor: ${setor}`, innerLeft + colWidth + 2, infoRowY + 6, { bold: false, size: 9 });
+  drawInfoCell(doc, `Data: ${dataInspecao}`, innerLeft + colWidth * 2 + 2, infoRowY + 6, {
+    bold: false,
+    size: 9,
+  });
+
+  const machineLineY = infoRowY + infoRowHeight + 8;
+  const machineText = `${(data.maquinaNome || "-").toUpperCase()}   TAG ${data.tag || "-"}`;
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(11);
+  doc.text(machineText, innerLeft, machineLineY);
+  doc.line(innerLeft, machineLineY + 2, innerLeft + infoSectionWidth, machineLineY + 2);
+
+  const photoBoxY = infoRowY;
+  doc.rect(photoBoxX, photoBoxY, photoBoxWidth, photoBoxHeight);
+  const parsedPhoto = parseImageSource(data.fotoMaquinaUrl);
+  if (parsedPhoto) {
+    const inset = 3;
+    const targetW = photoBoxWidth - inset * 2;
+    const targetH = photoBoxHeight - inset * 2;
+    doc.addImage(
+      parsedPhoto.data,
+      parsedPhoto.format,
+      photoBoxX + inset,
+      photoBoxY + inset,
+      targetW,
+      targetH,
+      undefined,
+      "FAST"
+    );
+  } else {
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    doc.setTextColor(120);
+    doc.text("FOTO DA MÁQUINA", photoBoxX + photoBoxWidth / 2, photoBoxY + photoBoxHeight / 2, {
+      align: "center",
+      baseline: "middle",
+    });
+    doc.setTextColor(0);
+  }
+
+  const headerBottom = Math.max(photoBoxY + photoBoxHeight + innerPadding, machineLineY + 10);
+  const headerHeight = headerBottom - top;
+  doc.rect(margin, top, contentWidth, headerHeight);
+
+  return { headerHeightMm: headerHeight };
+}

--- a/src/types/checklists.ts
+++ b/src/types/checklists.ts
@@ -1,0 +1,69 @@
+export type NonConformityStatus = "open" | "in_progress" | "resolved";
+
+export interface ChecklistAnswer {
+  questionId: string;
+  questionText?: string | null;
+  response: "c" | "nc" | "na";
+  observation?: string | null;
+  photoUrls?: string[];
+  recurrence?: boolean;
+}
+
+export interface ChecklistNonConformityTreatment {
+  questionId: string;
+  summary?: string | null;
+  responsible?: string | null;
+  dueDate?: string | null;
+  status: NonConformityStatus;
+  createdAt: string;
+  updatedAt?: string | null;
+}
+
+export interface ChecklistResponseMaintainer {
+  maintId?: string | null;
+  nome?: string | null;
+  matricula?: string | null;
+}
+
+export interface ChecklistResponseMachine {
+  machineId?: string | null;
+  tag?: string | null;
+  nome?: string | null;
+  modelo?: string | null;
+  setor?: string | null;
+  unidade?: string | null;
+  localUnidade?: string | null;
+  lac?: string | null;
+  fotoUrl?: string | null;
+  templateId?: string | null;
+}
+
+export interface ChecklistResponseTemplate {
+  id?: string | null;
+  nome?: string | null;
+  versao?: string | null;
+}
+
+export interface ChecklistResponse {
+  id: string;
+  machine?: ChecklistResponseMachine | null;
+  template?: ChecklistResponseTemplate | null;
+  maintainer?: ChecklistResponseMaintainer | null;
+  answers?: ChecklistAnswer[];
+  itens?: unknown;
+  nonConformityTreatments?: ChecklistNonConformityTreatment[];
+  observacoes?: string | null;
+  osNumero?: string | null;
+  assinaturaUrl?: string | null;
+  pcmSign?: {
+    nome?: string | null;
+    cargo?: string | null;
+    assinaturaUrl?: string | null;
+    signedAt?: string | null;
+  } | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+  iniciadaEm?: string | null;
+  finalizadaEm?: string | null;
+  qtdNC?: number;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -94,3 +94,5 @@ export type Issue = {
   createdAt: string;
   resolvedAt?: string;
 };
+
+export * from "./checklists";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,18 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add an /admin/inspecoes landing page that highlights PCM modules and lists inspections with quick actions and status badges
- enhance the pending signature workflow to show full inspection details, auto-open from links, and broadcast completion back to the hub
- include the PCM assistant signature in generated inspection PDFs for downstream records
- fix the PCM signature upload by encoding the imgbb request to avoid runtime submission errors
- add a shortcut from the PCM dashboard to the inspections hub so the new module is easier to reach
- replace the inspection PDF header with the Lar-standard layout while leaving the existing tables and signatures intact

## Testing
- npm run typecheck
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc3f7d07483288920e709e6feb362