### PR TITLE
Fix PCM signature canvas export

### DIFF
--- a/src/app/admin/inspecoes/assinar/page.tsx
+++ b/src/app/admin/inspecoes/assinar/page.tsx
@@ -509,10 +509,23 @@ export default function PendingSignaturesPage() {
 
     const trimmedCargo = cargo.trim();
 
+    let assinaturaDataUrl: string | null = null;
+    try {
+      const rawCanvas = canvas.getCanvas();
+      assinaturaDataUrl = rawCanvas.toDataURL("image/png");
+    } catch (err) {
+      console.error("[pcm-sign] failed to export canvas:", err);
+      assinaturaDataUrl = null;
+    }
+
+    if (!assinaturaDataUrl) {
+      setModalError("Não foi possível processar a assinatura. Tente novamente.");
+      return;
+    }
+
     try {
       setModalLoading(true);
       setModalError(null);
-      const assinaturaDataUrl = canvas.getTrimmedCanvas().toDataURL("image/png");
       const payload = {
         nome: trimmedName,
         cargo: trimmedCargo ? trimmedCargo : undefined,

--- a/src/components/signature-canvas-client.tsx
+++ b/src/components/signature-canvas-client.tsx
@@ -1,13 +1,19 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import { forwardRef } from "react";
-import SignatureCanvas from "react-signature-canvas";
+import type { default as SignatureCanvasType } from "react-signature-canvas";
 
-export type SignatureCanvasInstance = SignatureCanvas;
-export type SignatureCanvasProps = React.ComponentProps<typeof SignatureCanvas>;
+const SignatureCanvasDynamic = dynamic(() => import("react-signature-canvas"), {
+  ssr: false,
+}) as unknown as SignatureCanvasType;
+
+export type SignatureCanvasInstance = SignatureCanvasType;
+export type SignatureCanvasProps = React.ComponentProps<SignatureCanvasType>;
 
 const SignatureCanvasWithRef = forwardRef<SignatureCanvasInstance, SignatureCanvasProps>((props, ref) => (
-  <SignatureCanvas {...props} ref={ref} />
+  // @ts-expect-error – ref typing is not preserved by next/dynamic
+  <SignatureCanvasDynamic {...props} ref={ref} />
 ));
 
 SignatureCanvasWithRef.displayName = "SignatureCanvasWithRef";


### PR DESCRIPTION
## Summary
- load react-signature-canvas via dynamic import to avoid SSR issues
- export PCM signatures using the raw canvas data URL instead of getTrimmedCanvas
- add error handling when the signature canvas cannot be converted to PNG

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfe30890e08328b5fdcb7f87048042