### PR TITLE
Revamp Lar PDF header layout

### DIFF
--- a/src/server/pdf/header-lar.ts
+++ b/src/server/pdf/header-lar.ts
@@ -11,6 +11,13 @@ export type LarHeaderData = {
   tag: string;
   fotoMaquinaDataUrl?: string;
   ordemServico?: string;
+  templateTitle?: string;
+  templateVersion?: string;
+  operatorNome?: string;
+  operatorMatricula?: string;
+  dataHoraISO?: string;
+  lac?: string;
+  local?: string;
 };
 
 const M = 10;
@@ -19,13 +26,19 @@ const H_TOP = 28;
 const W_LOGO = 38;
 const W_TITLE = 80;
 const W_BOX = 72;
-const H_INFO = 18;
 const H_INFO_ROW1 = 9;
-const H_TAG_LINE = 7;
-const Y_PHOTO = M + H_TOP + H_INFO + H_TAG_LINE + 3;
-const H_PHOTO = 34;
-const X_PHOTO = M + W_LOGO + W_TITLE + 2;
+const H_INFO_ROW2 = 9;
+const H_INFO = H_INFO_ROW1 + H_INFO_ROW2;
+const W_LEFT = W - W_BOX;
+const Y_PANEL = M + H_TOP + H_INFO;
+const DEFAULT_H_PANEL = 40;
+const X_PHOTO = M + W_LEFT + 2;
+const Y_PHOTO = M + H_TOP + 2;
 const W_PHOTO = W_BOX - 4;
+const DEFAULT_H_PHOTO = 36;
+const H_MACHINE_LABEL = 7;
+const MACHINE_LABEL_GAP = 2;
+const H_PHOTO = DEFAULT_H_PHOTO;
 
 let cachedLarLogoDataUrl: string | null | undefined;
 
@@ -62,12 +75,18 @@ function formatDate(iso?: string): string {
   return `${day}/${month}/${year}`;
 }
 
-type ImageFormat = "PNG" | "JPEG" | "WEBP";
-
-function resolveImageFormat(dataUrl: string): ImageFormat {
-  if (dataUrl.startsWith("data:image/png")) return "PNG";
-  if (dataUrl.startsWith("data:image/webp")) return "WEBP";
-  return "JPEG";
+function formatDateTime(iso?: string): string {
+  if (!iso) return "__/__/____ __:__";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "__/__/____ __:__";
+  }
+  const day = String(date.getDate()).padStart(2, "0");
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = String(date.getFullYear());
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  return `${day}/${month}/${year} ${hours}:${minutes}`;
 }
 
 function drawImageContain(doc: jsPDF, dataUrl: string, x: number, y: number, w: number, h: number) {
@@ -81,7 +100,7 @@ function drawImageContain(doc: jsPDF, dataUrl: string, x: number, y: number, w: 
   }
   const dx = x + (w - drawWidth) / 2;
   const dy = y + (h - drawHeight) / 2;
-  const format = resolveImageFormat(dataUrl);
+  const format = (properties.fileType as any) || "PNG";
   doc.addImage(dataUrl, format, dx, dy, drawWidth, drawHeight);
 }
 
@@ -168,17 +187,14 @@ export function drawLarHeader(doc: jsPDF, data: LarHeaderData): {
 
   // Identification block
   const infoTop = M + H_TOP;
-  const infoBottom = infoTop + H_INFO;
   const infoLeft = M;
-  const infoRight = M + W;
+  const leftBlockWidth = W_LEFT;
+  const infoBottom = infoTop + H_INFO;
   const rowDividerY = infoTop + H_INFO_ROW1;
-  const leftBlockWidth = W - W_BOX;
-  const leftBlockRight = infoLeft + leftBlockWidth;
 
   doc.setLineWidth(0.4);
-  doc.rect(infoLeft, infoTop, W, H_INFO);
-  doc.line(infoLeft, rowDividerY, infoRight, rowDividerY);
-  doc.line(leftBlockRight, infoTop, leftBlockRight, infoBottom);
+  doc.rect(infoLeft, infoTop, leftBlockWidth, H_INFO);
+  doc.line(infoLeft, rowDividerY, infoLeft + leftBlockWidth, rowDividerY);
 
   const colUnidadeWidth = leftBlockWidth * 0.45;
   const colSetorWidth = leftBlockWidth * 0.35;
@@ -215,7 +231,7 @@ export function drawLarHeader(doc: jsPDF, data: LarHeaderData): {
 
   const osLabelWidth = doc.getTextWidth(`${osLabel} `);
   const osLineStartX = infoLeft + 2 + osLabelWidth;
-  const osLineEndX = leftBlockRight - 2;
+  const osLineEndX = infoLeft + leftBlockWidth - 2;
   const osLineY = infoBottom - 2;
   doc.setLineWidth(0.3);
   doc.line(osLineStartX, osLineY, osLineEndX, osLineY);
@@ -227,22 +243,6 @@ export function drawLarHeader(doc: jsPDF, data: LarHeaderData): {
     doc.text(ordemServico, osLineStartX + 1, osLineY - 1);
   }
 
-  // Tag line
-  const tagTextX = leftBlockRight + 2;
-  const tagTextY = infoBottom + 5;
-  const machineName = (data.maquinaNome || "").toUpperCase();
-  const tagValue = data.tag?.trim() || "";
-  const tagLineText = `${machineName}  TAG ${tagValue}`.trim();
-  doc.setFont("helvetica", "bold");
-  doc.setFontSize(10.5);
-  doc.text(tagLineText, tagTextX, tagTextY);
-
-  const textWidth = doc.getTextWidth(`${tagLineText} `);
-  const lineStartX = Math.min(tagTextX + textWidth + 1, M + W - 35);
-  const lineEndX = Math.min(lineStartX + 32, M + W - 2);
-  doc.setLineWidth(0.3);
-  doc.line(lineStartX, tagTextY - 1, lineEndX, tagTextY - 1);
-
   // Photo area
   const photoBox = { x: X_PHOTO, y: Y_PHOTO, w: W_PHOTO, h: H_PHOTO };
   doc.setLineWidth(0.3);
@@ -253,6 +253,125 @@ export function drawLarHeader(doc: jsPDF, data: LarHeaderData): {
     drawImageContain(doc, photoDataUrl, photoBox.x, photoBox.y, photoBox.w, photoBox.h);
   }
 
-  const topHeightMm = H_TOP + H_INFO + H_TAG_LINE;
+  // Machine label below photo
+  const machineName = (data.maquinaNome || "").toUpperCase();
+  const machineTag = data.tag?.trim();
+  const machineLabelText = machineTag ? `${machineName}  TAG ${machineTag}` : machineName;
+  const machineLabelY = Y_PHOTO + H_PHOTO + MACHINE_LABEL_GAP;
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(10.5);
+  doc.text(machineLabelText, photoBox.x + photoBox.w / 2, machineLabelY + H_MACHINE_LABEL / 2, {
+    align: "center",
+    baseline: "middle",
+  });
+
+  // Information panel
+  const panelX = M;
+  const panelY = Y_PANEL;
+  const panelWidth = W_LEFT;
+  const panelPadding = 3;
+  const lineHeight = 5;
+  const fieldSpacing = 1.5;
+  const availableWidth = panelWidth - panelPadding * 2;
+
+  const panelTemplateTitle = data.templateTitle?.trim() || data.tituloTemplate;
+  const panelTemplateVersion = data.templateVersion?.trim();
+  const templateValue = panelTemplateTitle
+    ? `${panelTemplateTitle}${panelTemplateVersion ? ` v${panelTemplateVersion}` : ""}`
+    : "—";
+
+  const operatorNome = data.operatorNome?.trim();
+  const operatorMatricula = data.operatorMatricula?.trim();
+  let mantenedorValue = "—";
+  if (operatorNome && operatorMatricula) {
+    mantenedorValue = `${operatorNome} (${operatorMatricula})`;
+  } else if (operatorNome) {
+    mantenedorValue = operatorNome;
+  } else if (operatorMatricula) {
+    mantenedorValue = `(${operatorMatricula})`;
+  }
+
+  const dateTimeValue = formatDateTime(data.dataHoraISO);
+  const ordemServicoValue = data.ordemServico?.trim() || "—";
+  const lacValue = data.lac?.trim() || "—";
+  const localValue = data.local?.trim();
+  const tagValue = machineTag || "—";
+
+  const panelFields = [
+    { label: "Máquina:", value: `${data.maquinaNome} (TAG ${tagValue})` },
+    { label: "Template:", value: templateValue },
+    { label: "Mantenedor:", value: mantenedorValue },
+    { label: "Data/Hora:", value: dateTimeValue },
+    { label: "OS:", value: ordemServicoValue || "—" },
+    { label: "LAC:", value: lacValue },
+  ];
+
+  if (localValue) {
+    panelFields.push({ label: "Local:", value: localValue });
+  }
+
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(8.5);
+  const labelMeasurements = panelFields.map(field => {
+    const labelWidth = doc.getTextWidth(`${field.label} `);
+    return labelWidth;
+  });
+
+  const measuredFields = panelFields.map((field, index) => {
+    const labelWidth = labelMeasurements[index];
+    const valueWidth = Math.max(availableWidth - labelWidth, availableWidth * 0.45);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    const lines = doc.splitTextToSize(field.value || "—", valueWidth);
+    const linesCount = Math.max(1, lines.length);
+    return { field, labelWidth, lines, linesCount };
+  });
+
+  const contentHeight =
+    panelPadding * 2 +
+    measuredFields.reduce((acc, current, idx) => {
+      const heightForField = lineHeight * current.linesCount;
+      const spacing = idx < measuredFields.length - 1 ? fieldSpacing : 0;
+      return acc + heightForField + spacing;
+    }, 0);
+
+  const panelHeight = Math.max(DEFAULT_H_PANEL, contentHeight);
+
+  doc.setLineWidth(0.4);
+  doc.setFillColor(230, 240, 255);
+  doc.rect(panelX, panelY, panelWidth, panelHeight, "FD");
+  doc.setDrawColor(0);
+
+  let textY = panelY + panelPadding + 4;
+  measuredFields.forEach(({ field, labelWidth, lines, linesCount }, index) => {
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(8.5);
+    const labelX = panelX + panelPadding;
+    doc.text(field.label, labelX, textY);
+
+    const valueX = labelX + labelWidth;
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(9);
+    const [firstLine, ...rest] = lines.length > 0 ? lines : ["—"];
+    doc.text(firstLine, valueX, textY);
+    let innerY = textY;
+    rest.forEach((line: string) => {
+      innerY += lineHeight;
+      doc.text(line, valueX, innerY);
+    });
+
+    textY += lineHeight * linesCount;
+    if (index < measuredFields.length - 1) {
+      textY += fieldSpacing;
+    }
+  });
+
+  doc.setFillColor(255, 255, 255);
+
+  const panelBottom = panelY + panelHeight;
+  const machineLabelBottom = machineLabelY + H_MACHINE_LABEL;
+  const bottom = Math.max(panelBottom, machineLabelBottom);
+  const topHeightMm = bottom - M;
+
   return { topHeightMm, photoBox };
 }

--- a/src/server/pdf/header-lar.ts
+++ b/src/server/pdf/header-lar.ts
@@ -100,7 +100,7 @@ function drawImageContain(doc: jsPDF, dataUrl: string, x: number, y: number, w: 
   }
   const dx = x + (w - drawWidth) / 2;
   const dy = y + (h - drawHeight) / 2;
-  const format = (properties.fileType as any) || "PNG";
+  const format = properties.fileType;
   doc.addImage(dataUrl, format, dx, dy, drawWidth, drawHeight);
 }
 


### PR DESCRIPTION
## Summary
- update the Lar PDF header drawing to match the new mock with the raised photo, centered machine label, and information panel
- provide the header with template, mantenedor, and machine metadata while removing the legacy "Relatório de Inspeção" section so the checklist starts right after the header

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e10bc0e5ac832894cb185af52cd472