### PR TITLE
Fix maintainer machine assignment handling

### DIFF
--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -176,7 +176,7 @@ export default function AdminNonConformitiesPage() {
       }
 
       const [machinesSnap, templatesSnap, responsesSnap] = await Promise.all([
-        getDocs(collection(firebaseDb, "maquinas")),
+        getDocs(collection(firebaseDb, "machines")),
         getDocs(collection(firebaseDb, "templates")),
         getDocs(query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"), limit(200))),
       ]);

--- a/src/app/api/inspecao/context/route.ts
+++ b/src/app/api/inspecao/context/route.ts
@@ -25,7 +25,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const machineQuery = await adminDb
-      .collection("maquinas")
+      .collection("machines")
       .where("tag", "==", tag)
       .limit(1)
       .get();
@@ -36,6 +36,10 @@ export async function GET(req: NextRequest) {
 
     const machineDoc = machineQuery.docs[0]!;
     const machineData = machineDoc.data();
+
+    if (machineData?.ativo === false) {
+      return NextResponse.json({ error: "MACHINE_INACTIVE" }, { status: 403 });
+    }
 
     const maintDoc = await adminDb.collection("mantenedores").doc(auth.store.id!).get();
     if (!maintDoc.exists) {

--- a/src/app/api/inspecoes/route.ts
+++ b/src/app/api/inspecoes/route.ts
@@ -99,7 +99,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const machineQuery = await adminDb
-      .collection("maquinas")
+      .collection("machines")
       .where("tag", "==", payload.tag)
       .limit(1)
       .get();
@@ -110,6 +110,10 @@ export async function POST(req: NextRequest) {
 
     const machineDoc = machineQuery.docs[0]!;
     const machineData = machineDoc.data();
+
+    if (machineData?.ativo === false) {
+      return NextResponse.json({ error: "MACHINE_INACTIVE" }, { status: 403 });
+    }
 
     const maintDoc = await adminDb.collection("mantenedores").doc(auth.store.id!).get();
     if (!maintDoc.exists) {

--- a/src/app/api/me/machines/route.ts
+++ b/src/app/api/me/machines/route.ts
@@ -1,20 +1,10 @@
 import { NextResponse } from "next/server";
-import { FieldPath } from "firebase-admin/firestore";
 import { adminDb } from "@/lib/firebase-admin";
 import { requireMaint } from "@/lib/guards";
+import { getMachinesByIdsChunked } from "@/lib/db/machines";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
-
-const CHUNK_SIZE = 10;
-
-function chunkArray<T>(items: T[], size: number) {
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
-}
 
 export async function GET() {
   const auth = await requireMaint();
@@ -37,37 +27,18 @@ export async function GET() {
       return NextResponse.json([]);
     }
 
-    const chunks = chunkArray(machinesIds, CHUNK_SIZE);
-    const results: Array<{
-      id: string;
-      tag: string | null;
-      nome: string | null;
-      setor: string | null;
-      unidade: string | null;
-      fotoUrl: string | null;
-    }> = [];
+    const docs = await getMachinesByIdsChunked(machinesIds);
 
-    for (const chunk of chunks) {
-      const snap = await adminDb
-        .collection("maquinas")
-        .where(FieldPath.documentId(), "in", chunk)
-        .get();
-
-      snap.docs.forEach(doc => {
-        const data = doc.data() ?? {};
-        if (data.ativo === false) {
-          return;
-        }
-        results.push({
-          id: doc.id,
-          tag: data.tag ?? null,
-          nome: data.nome ?? null,
-          setor: data.setor ?? null,
-          unidade: data.unidade ?? null,
-          fotoUrl: data.fotoUrl ?? null,
-        });
-      });
-    }
+    const results = docs
+      .filter(doc => doc.ativo !== false)
+      .map(doc => ({
+        id: doc.id,
+        tag: typeof doc.tag === "string" ? doc.tag : null,
+        nome: typeof doc.nome === "string" ? doc.nome : null,
+        setor: typeof doc.setor === "string" ? doc.setor : null,
+        unidade: typeof doc.unidade === "string" ? doc.unidade : null,
+        fotoUrl: typeof doc.fotoUrl === "string" ? doc.fotoUrl : null,
+      }));
 
     results.sort((a, b) => {
       const nameA = (a.nome ?? "").toLowerCase();

--- a/src/lib/db/machines.ts
+++ b/src/lib/db/machines.ts
@@ -1,0 +1,104 @@
+import { FieldPath } from "firebase-admin/firestore";
+
+import { adminDb } from "@/lib/firebase-admin";
+
+const MACHINES_COLLECTION = "machines";
+
+export type MachineDoc = {
+  id: string;
+  nome?: string | null;
+  tag?: string | null;
+  setor?: string | null;
+  unidade?: string | null;
+  localUnidade?: string | null;
+  lac?: string | null;
+  templateId?: string | null;
+  fotoUrl?: string | null;
+  ativo?: boolean | null;
+  [key: string]: unknown;
+};
+
+function mapMachineDoc(docSnap: FirebaseFirestore.DocumentSnapshot): MachineDoc {
+  const data = docSnap.data() ?? {};
+  const record: MachineDoc = { id: docSnap.id, ...data } as MachineDoc;
+  delete (record as Record<string, unknown>).id;
+  record.id = docSnap.id;
+  return record;
+}
+
+function chunkIds(ids: string[], size = 10): string[][] {
+  const chunks: string[][] = [];
+  for (let i = 0; i < ids.length; i += size) {
+    chunks.push(ids.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export async function getMachinesByIdsChunked(ids: string[]): Promise<MachineDoc[]> {
+  if (!ids?.length) return [];
+
+  const chunks = chunkIds(ids);
+  const results = new Map<string, MachineDoc>();
+
+  for (const chunk of chunks) {
+    const snapshot = await adminDb
+      .collection(MACHINES_COLLECTION)
+      .where(FieldPath.documentId(), "in", chunk)
+      .get();
+
+    snapshot.forEach(docSnap => {
+      const record = mapMachineDoc(docSnap);
+      results.set(record.id, record);
+    });
+  }
+
+  const ordered: MachineDoc[] = [];
+  const seen = new Set<string>();
+
+  ids.forEach(id => {
+    if (seen.has(id)) return;
+    const record = results.get(id);
+    if (record) {
+      ordered.push(record);
+      seen.add(id);
+    }
+  });
+
+  results.forEach(record => {
+    if (!seen.has(record.id)) {
+      ordered.push(record);
+      seen.add(record.id);
+    }
+  });
+
+  return ordered;
+}
+
+export async function listActiveMachines(): Promise<MachineDoc[]> {
+  const snapshot = await adminDb
+    .collection(MACHINES_COLLECTION)
+    .where("ativo", "==", true)
+    .get();
+
+  const records: MachineDoc[] = [];
+  snapshot.forEach(docSnap => {
+    records.push(mapMachineDoc(docSnap));
+  });
+
+  return records;
+}
+
+export async function listAllMachines(limit = 100): Promise<MachineDoc[]> {
+  const snapshot = await adminDb
+    .collection(MACHINES_COLLECTION)
+    .orderBy("createdAt", "desc")
+    .limit(limit)
+    .get();
+
+  const records: MachineDoc[] = [];
+  snapshot.forEach(docSnap => {
+    records.push(mapMachineDoc(docSnap));
+  });
+
+  return records;
+}


### PR DESCRIPTION
## Summary
- add a shared Firestore machines repository with chunked ID queries and active listings
- extend the maintainer machine API with detailed GET diagnostics, relaxed PUT validation, and debugging logs
- refresh the admin assignment UI to consume the new payload, surface inactive or missing machines, and allow cleanup
- align remaining API queries with the `machines` collection and enforce the `ativo` flag in inspections and context

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e11aed716c83288acdd78b1582604d