### PR TITLE
Fix machine lookup failing for numeric tags

### DIFF
--- a/src/app/api/inspecao/context/route.ts
+++ b/src/app/api/inspecao/context/route.ts
@@ -35,10 +35,6 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "MACHINE_INACTIVE" }, { status: 403 });
     }
 
-    if (machineData?.ativo === false) {
-      return NextResponse.json({ error: "MACHINE_INACTIVE" }, { status: 403 });
-    }
-
     const maintDoc = await adminDb.collection("mantenedores").doc(auth.store.id!).get();
     if (!maintDoc.exists) {
       return NextResponse.json({ error: "MAINTAINER_NOT_FOUND" }, { status: 403 });

--- a/src/app/api/inspecoes/route.ts
+++ b/src/app/api/inspecoes/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { FieldPath } from "firebase-admin/firestore";
 import type { QueryDocumentSnapshot, DocumentData } from "firebase-admin/firestore";
 import { adminDb } from "@/lib/firebase-admin";
+import { findMachineByTag } from "@/lib/db/machines";
 import { requireMaint } from "@/lib/guards";
 import { uploadToImgbbFromDataUrl } from "@/lib/imgbb";
 import { randomUUID } from "crypto";
@@ -98,20 +99,13 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const machineQuery = await adminDb
-      .collection("machines")
-      .where("tag", "==", payload.tag)
-      .limit(1)
-      .get();
+    const machineRecord = await findMachineByTag(payload.tag);
 
-    if (machineQuery.empty) {
+    if (!machineRecord) {
       return NextResponse.json({ error: "MACHINE_NOT_FOUND" }, { status: 404 });
     }
 
-    const machineDoc = machineQuery.docs[0]!;
-    const machineData = machineDoc.data();
-
-    if (machineData?.ativo === false) {
+    if (machineRecord.ativo === false) {
       return NextResponse.json({ error: "MACHINE_INACTIVE" }, { status: 403 });
     }
 
@@ -124,11 +118,11 @@ export async function POST(req: NextRequest) {
       ? (maintDoc.data()?.machines as string[])
       : [];
 
-    if (!maintMachines.includes(machineDoc.id)) {
+    if (!maintMachines.includes(machineRecord.id)) {
       return NextResponse.json({ error: "FORBIDDEN" }, { status: 403 });
     }
 
-    const templateId = String(machineData.templateId ?? "").trim();
+    const templateId = String(machineRecord.templateId ?? "").trim();
     if (!templateId) {
       return NextResponse.json({ error: "TEMPLATE_NOT_DEFINED" }, { status: 400 });
     }
@@ -221,7 +215,7 @@ export async function POST(req: NextRequest) {
 
     const openIssuesSnap = await adminDb
       .collection("issues")
-      .where("machineId", "==", machineDoc.id)
+      .where("machineId", "==", machineRecord.id)
       .where("status", "==", "aberta")
       .get();
 
@@ -256,8 +250,8 @@ export async function POST(req: NextRequest) {
       const descricao = item.observacaoItem || buildIssueDescription(templateItem, "NC identificada na inspeção");
       const issueRef = adminDb.collection("issues").doc();
       await issueRef.set({
-        machineId: machineDoc.id,
-        tag: machineData.tag ?? null,
+        machineId: machineRecord.id,
+        tag: machineRecord.tag ?? null,
         templateItemId: item.templateItemId,
         descricao,
         osNumero: osNumero ?? null,
@@ -281,7 +275,7 @@ export async function POST(req: NextRequest) {
           .get();
         for (const doc of snap.docs) {
           const data = doc.data() ?? {};
-          if (data.machineId !== machineDoc.id || data.status === "resolvida") {
+          if (data.machineId !== machineRecord.id || data.status === "resolvida") {
             continue;
           }
           await doc.ref.update({
@@ -298,14 +292,14 @@ export async function POST(req: NextRequest) {
 
     await inspectionRef.set({
       machine: {
-        machineId: machineDoc.id,
-        tag: machineData.tag ?? null,
-        nome: machineData.nome ?? null,
-        setor: machineData.setor ?? null,
-        unidade: machineData.unidade ?? null,
-        localUnidade: machineData.localUnidade ?? null,
-        lac: machineData.lac ?? null,
-        fotoUrl: machineData.fotoUrl ?? null,
+        machineId: machineRecord.id,
+        tag: machineRecord.tag ?? null,
+        nome: machineRecord.nome ?? null,
+        setor: machineRecord.setor ?? null,
+        unidade: machineRecord.unidade ?? null,
+        localUnidade: machineRecord.localUnidade ?? null,
+        lac: machineRecord.lac ?? null,
+        fotoUrl: machineRecord.fotoUrl ?? null,
         templateId,
       },
       template: {

--- a/src/lib/db/machines.ts
+++ b/src/lib/db/machines.ts
@@ -128,17 +128,34 @@ async function findMachineByTagInCollection(
   collectionName: string,
   tag: string,
 ): Promise<MachineDoc | null> {
-  const snapshot = await adminDb
-    .collection(collectionName)
-    .where("tag", "==", tag)
-    .limit(1)
-    .get();
-
-  if (snapshot.empty) {
+  const trimmedTag = tag.trim();
+  if (!trimmedTag) {
     return null;
   }
 
-  return mapMachineDoc(snapshot.docs[0]!);
+  const collectionRef = adminDb.collection(collectionName);
+
+  const snapshot = await collectionRef.where("tag", "==", trimmedTag).limit(1).get();
+
+  if (!snapshot.empty) {
+    return mapMachineDoc(snapshot.docs[0]!);
+  }
+
+  if (/^\d+$/.test(trimmedTag)) {
+    const numericTag = Number(trimmedTag);
+    if (Number.isSafeInteger(numericTag)) {
+      const numericSnapshot = await collectionRef
+        .where("tag", "==", numericTag)
+        .limit(1)
+        .get();
+
+      if (!numericSnapshot.empty) {
+        return mapMachineDoc(numericSnapshot.docs[0]!);
+      }
+    }
+  }
+
+  return null;
 }
 
 export async function findMachineByTag(tag: string): Promise<MachineDoc | null> {


### PR DESCRIPTION
## Summary
- allow the machine lookup helper to match tags stored as either strings or numbers
- reuse the shared lookup when loading inspection data and remove a redundant inactive-machine check
- ensure inspection creation reads machine metadata through the shared helper so numeric tags resolve correctly

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3a9f7143c83288ed5f8a5ba0ab802