### PR TITLE
Add inspection draft support and maintainer in-progress carousel

### DIFF
--- a/src/app/api/inspecoes/drafts/[tag]/route.ts
+++ b/src/app/api/inspecoes/drafts/[tag]/route.ts
@@ -1,0 +1,277 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { adminDb } from "@/lib/firebase-admin";
+import { findMachineByTag } from "@/lib/db/machines";
+import { requireMaint } from "@/lib/guards";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const itemSchema = z.object({
+  templateItemId: z.string().trim().min(1),
+  resultado: z.enum(["", "C", "NC", "NA"]).default(""),
+  observacao: z.string().trim().max(4000).optional(),
+});
+
+const payloadSchema = z.object({
+  osNumero: z.string().trim().max(120).optional(),
+  observacoes: z.string().trim().max(4000).optional(),
+  assinaturaDataUrl: z.string().trim().max(200_000).nullable().optional(),
+  itens: z.array(itemSchema).optional(),
+  resolveIssues: z.array(z.string().trim().min(1)).optional(),
+});
+
+function ensureDataUrl(value: string | null | undefined) {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return null;
+  if (!/^data:[^;]+;base64,/i.test(trimmed)) {
+    throw new Error("INVALID_DATA_URL");
+  }
+  return trimmed;
+}
+
+function coerceString(value: unknown) {
+  return typeof value === "string" ? value : null;
+}
+
+function buildDraftId(maintainerId: string, machineId: string) {
+  return `${maintainerId}__${machineId}`;
+}
+
+type RouteContext = {
+  params: Promise<Record<string, string | string[] | undefined>>;
+};
+
+function extractTag(params: Record<string, string | string[] | undefined>) {
+  const tagValue = params.tag;
+  return Array.isArray(tagValue) ? tagValue[0] ?? "" : tagValue ?? "";
+}
+
+async function resolveContext(tagParam: string, maintainerId: string) {
+  const tag = tagParam.trim();
+  if (!tag) {
+    return { ok: false as const, status: 400, error: "TAG_REQUIRED" };
+  }
+
+  const machineRecord = await findMachineByTag(tag);
+  if (!machineRecord) {
+    return { ok: false as const, status: 404, error: "MACHINE_NOT_FOUND" };
+  }
+
+  if (machineRecord.ativo === false) {
+    return { ok: false as const, status: 403, error: "MACHINE_INACTIVE" };
+  }
+
+  const maintDoc = await adminDb.collection("mantenedores").doc(maintainerId).get();
+  if (!maintDoc.exists) {
+    return { ok: false as const, status: 403, error: "MAINTAINER_NOT_FOUND" };
+  }
+
+  const maintMachines = Array.isArray(maintDoc.data()?.machines)
+    ? (maintDoc.data()?.machines as string[])
+    : [];
+  if (!maintMachines.includes(machineRecord.id)) {
+    return { ok: false as const, status: 403, error: "FORBIDDEN" };
+  }
+
+  const templateId = String(machineRecord.templateId ?? "").trim();
+  if (!templateId) {
+    return { ok: false as const, status: 400, error: "TEMPLATE_NOT_DEFINED" };
+  }
+
+  const templateSnap = await adminDb.collection("templates").doc(templateId).get();
+  if (!templateSnap.exists) {
+    return { ok: false as const, status: 404, error: "TEMPLATE_NOT_FOUND" };
+  }
+
+  const templateData = templateSnap.data() ?? {};
+  const templateItems = Array.isArray(templateData.itens) ? templateData.itens : [];
+
+  return {
+    ok: true as const,
+    machineRecord,
+    templateId,
+    templateNome: templateData.nome ?? null,
+    templateItems,
+  };
+}
+
+export async function GET(_req: NextRequest, context: RouteContext) {
+  const auth = await requireMaint();
+  if (!auth.ok) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: auth.status });
+  }
+
+  const params = (await context.params) ?? {};
+  const tagParam = extractTag(params);
+
+  const resolved = await resolveContext(tagParam, auth.store.id!);
+  if (!resolved.ok) {
+    return NextResponse.json({ error: resolved.error }, { status: resolved.status });
+  }
+
+  const draftId = buildDraftId(auth.store.id!, resolved.machineRecord.id);
+  const draftSnap = await adminDb.collection("inspectionDrafts").doc(draftId).get();
+  if (!draftSnap.exists) {
+    return NextResponse.json({ draft: null });
+  }
+
+  const data = draftSnap.data() ?? {};
+  if (coerceString(data.templateId) !== resolved.templateId) {
+    await draftSnap.ref.delete().catch(() => undefined);
+    return NextResponse.json({ draft: null });
+  }
+
+  const itensData = typeof data.itens === "object" && data.itens ? (data.itens as Record<string, unknown>) : {};
+  const resolveIssues = Array.isArray(data.resolveIssues)
+    ? (data.resolveIssues as unknown[]).filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const itens = resolved.templateItems
+    .filter(item => item?.id)
+    .map(item => {
+      const entry = itensData[item.id as string] as Record<string, unknown> | undefined;
+      const resultado = coerceString(entry?.resultado) ?? "";
+      const observacao = coerceString(entry?.observacao) ?? "";
+      return {
+        templateItemId: item.id as string,
+        resultado,
+        observacao,
+      };
+    });
+
+  const total = typeof data.totalItens === "number" ? data.totalItens : itens.length;
+  const answered = typeof data.answeredItens === "number" ? data.answeredItens : itens.filter(item => item.resultado).length;
+  const percent = total > 0 ? Math.max(0, Math.min(100, Math.round((answered / total) * 100))) : 0;
+
+  return NextResponse.json({
+    draft: {
+      osNumero: coerceString(data.osNumero) ?? "",
+      observacoes: coerceString(data.observacoes) ?? "",
+      assinaturaDataUrl: coerceString(data.assinaturaDataUrl),
+      itens,
+      totalItens: total,
+      answeredItens: answered,
+      progressPercent: percent,
+      updatedAt: coerceString(data.updatedAt),
+      resolveIssues,
+    },
+  });
+}
+
+export async function PUT(req: NextRequest, context: RouteContext) {
+  const auth = await requireMaint();
+  if (!auth.ok) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: auth.status });
+  }
+
+  const params = (await context.params) ?? {};
+  const tagParam = extractTag(params);
+
+  const resolved = await resolveContext(tagParam, auth.store.id!);
+  if (!resolved.ok) {
+    return NextResponse.json({ error: resolved.error }, { status: resolved.status });
+  }
+
+  let payload: z.infer<typeof payloadSchema>;
+  try {
+    payload = payloadSchema.parse(await req.json());
+  } catch (err: unknown) {
+    const message = err instanceof Error && err.message ? err.message : "INVALID_PAYLOAD";
+    return NextResponse.json({ error: message }, { status: 422 });
+  }
+
+  let assinaturaDataUrl: string | null = null;
+  try {
+    assinaturaDataUrl = ensureDataUrl(payload.assinaturaDataUrl ?? null);
+  } catch {
+    return NextResponse.json({ error: "INVALID_SIGNATURE" }, { status: 422 });
+  }
+
+  const itens = (payload.itens ?? []).filter(item => resolved.templateItems.some(templateItem => templateItem?.id === item.templateItemId));
+  const resolveIssuesIds = Array.isArray(payload.resolveIssues)
+    ? payload.resolveIssues.filter(id => typeof id === "string" && id.trim().length > 0)
+    : [];
+  const itensMap: Record<string, { resultado: string; observacao: string | null }> = {};
+
+  let answered = 0;
+  for (const item of itens) {
+    const resultado = item.resultado ?? "";
+    const observacao = item.observacao?.trim() ? item.observacao.trim() : null;
+    itensMap[item.templateItemId] = { resultado, observacao };
+    if (resultado === "C" || resultado === "NC" || resultado === "NA") {
+      answered += 1;
+    }
+  }
+
+  const total = resolved.templateItems.filter(item => item?.id).length;
+  const osNumero = payload.osNumero?.trim() ? payload.osNumero.trim().toUpperCase() : null;
+  const observacoes = payload.observacoes?.trim() ? payload.observacoes.trim() : null;
+  const percent = total > 0 ? Math.max(0, Math.min(100, Math.round((answered / total) * 100))) : 0;
+  const nowIso = new Date().toISOString();
+
+  const draftId = buildDraftId(auth.store.id!, resolved.machineRecord.id);
+  const draftRef = adminDb.collection("inspectionDrafts").doc(draftId);
+  const existingSnap = await draftRef.get();
+  const createdAt = existingSnap.exists && typeof existingSnap.data()?.createdAt === "string" ? existingSnap.data()!.createdAt : nowIso;
+
+  const payloadToSave = {
+    maintainerId: auth.store.id!,
+    machineId: resolved.machineRecord.id,
+    machineTag: resolved.machineRecord.tag ?? null,
+    machineNome: resolved.machineRecord.nome ?? null,
+    machineSetor: resolved.machineRecord.setor ?? null,
+    machineUnidade: resolved.machineRecord.unidade ?? null,
+    templateId: resolved.templateId,
+    templateNome: resolved.templateNome ?? null,
+    osNumero,
+    observacoes,
+    assinaturaDataUrl,
+    itens: itensMap,
+    totalItens: total,
+    answeredItens: answered,
+    progressPercent: percent,
+    updatedAt: nowIso,
+    createdAt,
+    resolveIssues: resolveIssuesIds,
+  };
+
+  await draftRef.set(payloadToSave, { merge: false });
+
+  return NextResponse.json({
+    draft: {
+      osNumero: osNumero ?? "",
+      observacoes: observacoes ?? "",
+      assinaturaDataUrl,
+      itens: Object.entries(itensMap).map(([templateItemId, value]) => ({
+        templateItemId,
+        resultado: value.resultado,
+        observacao: value.observacao ?? "",
+      })),
+      totalItens: total,
+      answeredItens: answered,
+      progressPercent: percent,
+      updatedAt: nowIso,
+      resolveIssues: resolveIssuesIds,
+    },
+  });
+}
+
+export async function DELETE(_req: NextRequest, context: RouteContext) {
+  const auth = await requireMaint();
+  if (!auth.ok) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: auth.status });
+  }
+
+  const params = (await context.params) ?? {};
+  const tagParam = extractTag(params);
+
+  const resolved = await resolveContext(tagParam, auth.store.id!);
+  if (!resolved.ok) {
+    return NextResponse.json({ error: resolved.error }, { status: resolved.status });
+  }
+
+  const draftId = buildDraftId(auth.store.id!, resolved.machineRecord.id);
+  await adminDb.collection("inspectionDrafts").doc(draftId).delete().catch(() => undefined);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/inspecoes/drafts/route.ts
+++ b/src/app/api/inspecoes/drafts/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { adminDb } from "@/lib/firebase-admin";
+import { requireMaint } from "@/lib/guards";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function safeNumber(value: unknown, fallback = 0) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function safeString(value: unknown) {
+  return typeof value === "string" ? value : null;
+}
+
+function buildDraftPayload(doc: FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>) {
+  const data = doc.data() ?? {};
+  const total = safeNumber(data.totalItens);
+  const answered = Math.min(safeNumber(data.answeredItens), total > 0 ? total : Number.MAX_SAFE_INTEGER);
+  const percent = total > 0 ? Math.max(0, Math.min(100, Math.round((answered / total) * 100))) : 0;
+
+  return {
+    id: doc.id,
+    machineId: safeString(data.machineId),
+    machineTag: safeString(data.machineTag),
+    machineNome: safeString(data.machineNome),
+    machineUnidade: safeString(data.machineUnidade),
+    machineSetor: safeString(data.machineSetor),
+    templateId: safeString(data.templateId),
+    templateNome: safeString(data.templateNome),
+    answeredItens: answered,
+    totalItens: total,
+    progressPercent: percent,
+    updatedAt: safeString(data.updatedAt),
+    createdAt: safeString(data.createdAt),
+  };
+}
+
+export async function GET() {
+  const auth = await requireMaint();
+  if (!auth.ok) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: auth.status });
+  }
+
+  try {
+    const snapshot = await adminDb
+      .collection("inspectionDrafts")
+      .where("maintainerId", "==", auth.store.id!)
+      .orderBy("updatedAt", "desc")
+      .get();
+
+    const drafts = snapshot.docs.map(buildDraftPayload);
+    return NextResponse.json(drafts);
+  } catch (err: unknown) {
+    const message = err instanceof Error && err.message ? err.message : "INTERNAL_ERROR";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -18,6 +18,21 @@ type MachineRecord = {
   fotoUrl: string | null;
 };
 
+type DraftSummary = {
+  id: string;
+  machineId: string | null;
+  machineTag: string | null;
+  machineNome: string | null;
+  machineSetor: string | null;
+  machineUnidade: string | null;
+  templateId: string | null;
+  templateNome: string | null;
+  answeredItens: number;
+  totalItens: number;
+  progressPercent: number;
+  updatedAt: string | null;
+};
+
 export default function HomeMaint() {
   const router = useRouter();
   const [sessionLoading, setSessionLoading] = useState(true);
@@ -26,8 +41,11 @@ export default function HomeMaint() {
   const [machinesError, setMachinesError] = useState<string | null>(null);
   const [session, setSession] = useState<MaintSessionInfo | null>(null);
   const [machines, setMachines] = useState<MachineRecord[]>([]);
+  const [drafts, setDrafts] = useState<DraftSummary[]>([]);
   const [searchTag, setSearchTag] = useState("");
   const [logoutLoading, setLogoutLoading] = useState(false);
+  const [draftsLoading, setDraftsLoading] = useState(true);
+  const [draftsError, setDraftsError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -114,6 +132,68 @@ export default function HomeMaint() {
     };
   }, [session]);
 
+  useEffect(() => {
+    let cancelled = false;
+    async function loadDrafts() {
+      if (!session) {
+        setDrafts([]);
+        setDraftsLoading(false);
+        setDraftsError(null);
+        return;
+      }
+      setDraftsLoading(true);
+      setDraftsError(null);
+      try {
+        const response = await fetch("/api/inspecoes/drafts", { cache: "no-store" });
+        if (response.status === 401) {
+          window.location.href = "/login";
+          return;
+        }
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(typeof payload?.error === "string" ? payload.error : "Falha ao carregar rascunhos");
+        }
+        const data = await response.json();
+        if (!cancelled) {
+          const normalized = Array.isArray(data)
+            ? (data as DraftSummary[]).map(draft => ({
+                id: String(draft.id ?? ""),
+                machineId: draft.machineId ?? null,
+                machineTag: draft.machineTag ?? null,
+                machineNome: draft.machineNome ?? null,
+                machineSetor: draft.machineSetor ?? null,
+                machineUnidade: draft.machineUnidade ?? null,
+                templateId: draft.templateId ?? null,
+                templateNome: draft.templateNome ?? null,
+                answeredItens: Number.isFinite(draft.answeredItens) ? Number(draft.answeredItens) : 0,
+                totalItens: Number.isFinite(draft.totalItens) ? Number(draft.totalItens) : 0,
+                progressPercent:
+                  typeof draft.progressPercent === "number" && Number.isFinite(draft.progressPercent)
+                    ? Math.max(0, Math.min(100, Math.round(draft.progressPercent)))
+                    : 0,
+                updatedAt: draft.updatedAt ?? null,
+              }))
+            : [];
+          setDrafts(normalized);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const message = err instanceof Error && err.message ? err.message : "Falha ao carregar rascunhos";
+          setDraftsError(message);
+          setDrafts([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setDraftsLoading(false);
+        }
+      }
+    }
+    loadDrafts();
+    return () => {
+      cancelled = true;
+    };
+  }, [session]);
+
   const greeting = useMemo(() => {
     if (!session) return null;
     const nome = session.nome ? String(session.nome) : "";
@@ -136,6 +216,14 @@ export default function HomeMaint() {
       setLogoutLoading(false);
     }
   }, []);
+
+  const handleOpenDraft = useCallback(
+    (tag: string | null) => {
+      if (!tag) return;
+      router.push(`/inspecao/${encodeURIComponent(tag)}`);
+    },
+    [router]
+  );
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-8">
@@ -160,6 +248,95 @@ export default function HomeMaint() {
           </button>
         )}
       </header>
+
+      {greeting && (draftsLoading || draftsError || drafts.length > 0) && (
+        <section className="space-y-4 rounded-lg border border-blue-100 bg-white p-4 shadow-sm">
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900">Inspeções em andamento</h2>
+              <p className="text-sm text-gray-600">Continue de onde parou seus rascunhos.</p>
+            </div>
+            <span className="text-xs text-gray-500">
+              {draftsLoading ? "Carregando..." : drafts.length === 0 ? "Nenhum rascunho" : `${drafts.length} rascunho(s)`}
+            </span>
+          </div>
+          {draftsLoading ? (
+            <div className="flex gap-4 overflow-x-auto pb-2">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="min-w-[16rem] flex-shrink-0 rounded-lg border border-gray-200 bg-gray-100 p-4 shadow-sm"
+                >
+                  <div className="h-4 w-32 animate-pulse rounded bg-gray-300" />
+                  <div className="mt-3 h-2 w-full animate-pulse rounded bg-gray-300" />
+                  <div className="mt-2 h-2 w-2/3 animate-pulse rounded bg-gray-200" />
+                </div>
+              ))}
+            </div>
+          ) : draftsError ? (
+            <p className="text-sm text-red-600">{draftsError}</p>
+          ) : drafts.length === 0 ? (
+            <p className="text-sm text-gray-600">Nenhuma inspeção em andamento no momento.</p>
+          ) : (
+            <div className="flex gap-4 overflow-x-auto pb-2">
+              {drafts.map(draft => {
+                const progress = Math.max(
+                  0,
+                  Math.min(
+                    100,
+                    typeof draft.progressPercent === "number" && Number.isFinite(draft.progressPercent)
+                      ? Math.round(draft.progressPercent)
+                      : 0,
+                  ),
+                );
+                const answered = Number.isFinite(draft.answeredItens) ? draft.answeredItens : 0;
+                const total = Number.isFinite(draft.totalItens) ? draft.totalItens : 0;
+                const updatedLabel = draft.updatedAt ? new Date(draft.updatedAt).toLocaleString("pt-BR") : null;
+                const hasTag = Boolean(draft.machineTag);
+
+                return (
+                  <button
+                    key={draft.id}
+                    type="button"
+                    onClick={() => handleOpenDraft(draft.machineTag)}
+                    disabled={!hasTag}
+                    className={`min-w-[16rem] flex-shrink-0 rounded-lg border px-4 py-3 text-left shadow-sm transition ${
+                      hasTag
+                        ? "border-gray-200 bg-white hover:-translate-y-1 hover:border-blue-400 hover:shadow-md"
+                        : "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <p className="truncate text-sm font-semibold text-gray-900">
+                        {draft.machineNome ?? draft.machineTag ?? "Máquina"}
+                      </p>
+                      <span className="text-xs text-gray-500">TAG {draft.machineTag ?? "-"}</span>
+                    </div>
+                    <p className="mt-1 text-xs text-gray-500">
+                      {draft.machineSetor ?? "-"} • {draft.machineUnidade ?? "-"}
+                    </p>
+                    <div className="mt-3 space-y-1">
+                      <div className="flex items-center justify-between text-xs text-gray-600">
+                        <span>Progresso</span>
+                        <span>{progress}%</span>
+                      </div>
+                      <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200">
+                        <div className="h-full rounded-full bg-blue-500 transition-all" style={{ width: `${progress}%` }} />
+                      </div>
+                      <p className="text-[0.7rem] text-gray-500">
+                        {answered}/{total} itens respondidos
+                      </p>
+                      {updatedLabel && (
+                        <p className="text-[0.65rem] text-gray-400">Atualizado em {updatedLabel}</p>
+                      )}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </section>
+      )}
 
       {greeting && (
         <section className="space-y-4 rounded-lg border border-gray-200 bg-white p-4 shadow-sm">

--- a/src/app/inspecao/[tag]/page.tsx
+++ b/src/app/inspecao/[tag]/page.tsx
@@ -25,6 +25,15 @@ type InspectionContext = { maintainer: MaintainerInfo; machine: MachineInfo; tem
 
 type ItemFormState = { resultado: "" | "C" | "NC" | "NA"; observacao: string; fotos: File[]; fileKey: number };
 type FeedbackState = { type: "success" | "error"; message: string };
+type DraftItemState = { templateItemId: string; resultado: "" | "C" | "NC" | "NA"; observacao: string };
+type DraftDataState = {
+  osNumero: string;
+  observacoes: string;
+  assinaturaDataUrl: string | null;
+  itens: DraftItemState[];
+  resolveIssues: string[];
+  updatedAt?: string | null;
+};
 
 const RESULT_OPTIONS: Array<{ value: "C" | "NC" | "NA"; label: string; tone: "ok" | "nc" | "na" }> = [
   { value: "C", label: "C", tone: "ok" },
@@ -88,8 +97,18 @@ export default function InspectionPage() {
   const [lastInspectionId, setLastInspectionId] = useState<string | null>(null);
   const [reloadCounter, setReloadCounter] = useState(0);
 
+  const [draftLoading, setDraftLoading] = useState(false);
+  const [draftError, setDraftError] = useState<string | null>(null);
+  const [draftSaving, setDraftSaving] = useState(false);
+  const [autoSavingDraft, setAutoSavingDraft] = useState(false);
+  const [draftFeedback, setDraftFeedback] = useState<FeedbackState | null>(null);
+  const [lastDraftUpdatedAt, setLastDraftUpdatedAt] = useState<string | null>(null);
+  const draftTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastDraftPayloadRef = useRef<string | null>(null);
+
   const signatureRef = useRef<SignatureCanvasInstance | null>(null);
   const [signatureTouched, setSignatureTouched] = useState(false);
+  const [signatureDataUrl, setSignatureDataUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (searchParams?.get("ok") === "1") setFeedback({ type: "success", message: "Inspeção salva" });
@@ -142,14 +161,281 @@ export default function InspectionPage() {
   const resetForm = useCallback(() => {
     if (!context?.template?.itens) return;
     const initial: Record<string, ItemFormState> = {};
-    context.template.itens.filter((i) => i.id).forEach((i, idx) => {
-      initial[i.id!] = { resultado: "", observacao: "", fotos: [], fileKey: Date.now() + idx };
-    });
-    setItemsState(initial); setOsNumero(""); setObservacoes(""); setResolveIssues({});
-    setSignatureTouched(false); signatureRef.current?.clear?.();
+    context.template.itens
+      .filter(i => i.id)
+      .forEach((i, idx) => {
+        initial[i.id!] = { resultado: "", observacao: "", fotos: [], fileKey: Date.now() + idx };
+      });
+    setItemsState(initial);
+    setOsNumero("");
+    setObservacoes("");
+    setResolveIssues({});
+    setDraftFeedback(null);
+    setLastDraftUpdatedAt(null);
+    lastDraftPayloadRef.current = null;
+    setSignatureTouched(false);
+    setSignatureDataUrl(null);
+    signatureRef.current?.clear?.();
   }, [context?.template?.itens]);
 
   useEffect(() => { if (context) resetForm(); }, [context, resetForm]);
+
+  const applyDraft = useCallback(
+    (draft: DraftDataState) => {
+      const itemsMap = new Map(draft.itens.map(item => [item.templateItemId, item] as const));
+      const base: Record<string, ItemFormState> = {};
+      const now = Date.now();
+      sortedItems.forEach((item, idx) => {
+        if (!item.id) return;
+        const saved = itemsMap.get(item.id);
+        const resultado = saved?.resultado === "C" || saved?.resultado === "NC" || saved?.resultado === "NA" ? saved.resultado : "";
+        base[item.id] = {
+          resultado,
+          observacao: saved?.observacao ?? "",
+          fotos: [],
+          fileKey: now + idx,
+        };
+      });
+      setItemsState(base);
+      setOsNumero(draft.osNumero ?? "");
+      setObservacoes(draft.observacoes ?? "");
+      const validResolveIds = draft.resolveIssues
+        .filter(id => typeof id === "string" && id.trim().length > 0)
+        .map(id => id.trim())
+        .sort();
+      const resolveMap: Record<string, boolean> = {};
+      validResolveIds.forEach(id => {
+        resolveMap[id] = true;
+      });
+      setResolveIssues(resolveMap);
+      setDraftFeedback(null);
+      const updatedAt = draft.updatedAt ?? null;
+      setLastDraftUpdatedAt(updatedAt);
+      const signatureValue = draft.assinaturaDataUrl ?? null;
+      setSignatureDataUrl(signatureValue);
+      setSignatureTouched(!!signatureValue);
+      if (signatureValue) {
+        setTimeout(() => {
+          try {
+            signatureRef.current?.fromDataURL?.(signatureValue);
+          } catch {
+            // ignore load errors
+          }
+        }, 0);
+      } else {
+        signatureRef.current?.clear?.();
+      }
+      const normalizedItems: DraftItemState[] = sortedItems
+        .filter(item => item?.id)
+        .map(item => {
+          const saved = itemsMap.get(item.id as string);
+          const resultado = saved?.resultado === "C" || saved?.resultado === "NC" || saved?.resultado === "NA" ? saved.resultado : "";
+          const observacao = saved?.observacao?.trim() ?? "";
+          return {
+            templateItemId: item.id as string,
+            resultado,
+            observacao,
+          };
+        });
+      const normalizedPayload: DraftDataState = {
+        osNumero: (draft.osNumero ?? "").trim().toUpperCase(),
+        observacoes: (draft.observacoes ?? "").trim(),
+        assinaturaDataUrl: signatureValue,
+        itens: normalizedItems,
+        resolveIssues: validResolveIds,
+        updatedAt,
+      };
+      lastDraftPayloadRef.current = JSON.stringify(normalizedPayload);
+      if (draftTimerRef.current) {
+        clearTimeout(draftTimerRef.current);
+        draftTimerRef.current = null;
+      }
+    },
+    [sortedItems]
+  );
+
+  useEffect(() => {
+    if (!context?.machine?.tag) {
+      return;
+    }
+    let cancelled = false;
+    const currentTag = context.machine.tag ?? tag;
+    async function loadDraft() {
+      setDraftLoading(true);
+      setDraftError(null);
+      try {
+        const response = await fetch(`/api/inspecoes/drafts/${encodeURIComponent(currentTag)}` , {
+          cache: "no-store",
+        });
+        if (response.status === 401) {
+          window.location.href = "/login";
+          return;
+        }
+        if (!response.ok) {
+          const payload = await response.json().catch(() => null);
+          throw new Error(typeof payload?.error === "string" ? payload.error : "Falha ao carregar rascunho");
+        }
+        const data = await response.json();
+        if (cancelled) return;
+        const draft = data?.draft;
+        if (draft) {
+          applyDraft({
+            osNumero: draft.osNumero ?? "",
+            observacoes: draft.observacoes ?? "",
+            assinaturaDataUrl: draft.assinaturaDataUrl ?? null,
+            itens: Array.isArray(draft.itens) ? draft.itens : [],
+            resolveIssues: Array.isArray(draft.resolveIssues) ? draft.resolveIssues : [],
+            updatedAt: draft.updatedAt ?? null,
+          });
+        } else {
+          lastDraftPayloadRef.current = null;
+          setLastDraftUpdatedAt(null);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const message = err instanceof Error && err.message ? err.message : "Falha ao carregar rascunho";
+          setDraftError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setDraftLoading(false);
+        }
+      }
+    }
+    loadDraft();
+    return () => {
+      cancelled = true;
+    };
+  }, [context?.machine?.tag, applyDraft, tag]);
+
+  const buildCurrentDraftPayload = useCallback((): DraftDataState => {
+    const normalizedOs = osNumero.trim().toUpperCase();
+    const normalizedObs = observacoes.trim();
+    const itens: DraftItemState[] = [];
+    sortedItems.forEach(item => {
+      if (!item?.id) return;
+      const st = itemsState[item.id];
+      const resultado = st?.resultado === "C" || st?.resultado === "NC" || st?.resultado === "NA" ? st.resultado : "";
+      const observacao = st?.observacao?.trim() ?? "";
+      itens.push({
+        templateItemId: item.id,
+        resultado,
+        observacao,
+      });
+    });
+    const resolveIds = Object.entries(resolveIssues)
+      .filter(([, checked]) => checked)
+      .map(([id]) => id)
+      .sort();
+    return {
+      osNumero: normalizedOs,
+      observacoes: normalizedObs,
+      assinaturaDataUrl: signatureDataUrl ?? null,
+      itens,
+      resolveIssues: resolveIds,
+    };
+  }, [itemsState, observacoes, osNumero, resolveIssues, signatureDataUrl, sortedItems]);
+
+  const saveDraft = useCallback(
+    async (mode: "manual" | "auto") => {
+      if (!context?.machine?.tag) return;
+      const draftState = buildCurrentDraftPayload();
+      const fingerprint = JSON.stringify(draftState);
+      if (mode === "auto" && lastDraftPayloadRef.current === fingerprint) {
+        return;
+      }
+      if (mode === "manual" && lastDraftPayloadRef.current === fingerprint) {
+        setDraftFeedback({ type: "success", message: "Rascunho já está atualizado." });
+        return;
+      }
+
+      const payload = {
+        osNumero: draftState.osNumero || undefined,
+        observacoes: draftState.observacoes || undefined,
+        assinaturaDataUrl: draftState.assinaturaDataUrl,
+        itens: draftState.itens,
+        resolveIssues: draftState.resolveIssues,
+      };
+
+      try {
+        if (mode === "manual") {
+          setDraftSaving(true);
+          setDraftFeedback(null);
+        } else {
+          setAutoSavingDraft(true);
+        }
+        const response = await fetch(`/api/inspecoes/drafts/${encodeURIComponent(context.machine.tag)}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (response.status === 401) {
+          window.location.href = "/login";
+          return;
+        }
+        if (!response.ok) {
+          const payloadError = await response.json().catch(() => null);
+          throw new Error(typeof payloadError?.error === "string" ? payloadError.error : "Falha ao salvar rascunho");
+        }
+        const data = await response.json();
+        lastDraftPayloadRef.current = fingerprint;
+        const updatedAt = data?.draft?.updatedAt ?? new Date().toISOString();
+        setLastDraftUpdatedAt(updatedAt);
+        setDraftError(null);
+        if (draftTimerRef.current) {
+          clearTimeout(draftTimerRef.current);
+          draftTimerRef.current = null;
+        }
+        if (mode === "manual") {
+          setDraftFeedback({ type: "success", message: "Rascunho salvo com sucesso." });
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error && err.message ? err.message : "Falha ao salvar rascunho";
+        setDraftError(message);
+        if (mode === "manual") {
+          setDraftFeedback({ type: "error", message });
+        }
+      } finally {
+        if (mode === "manual") {
+          setDraftSaving(false);
+        } else {
+          setAutoSavingDraft(false);
+        }
+      }
+    },
+    [buildCurrentDraftPayload, context?.machine?.tag]
+  );
+
+  const handleManualDraftSave = useCallback(() => {
+    saveDraft("manual").catch(() => undefined);
+  }, [saveDraft]);
+
+  useEffect(() => {
+    if (!context?.machine?.tag || draftLoading) {
+      if (draftTimerRef.current) {
+        clearTimeout(draftTimerRef.current);
+        draftTimerRef.current = null;
+      }
+      return;
+    }
+    const draftState = buildCurrentDraftPayload();
+    const fingerprint = JSON.stringify(draftState);
+    if (fingerprint === lastDraftPayloadRef.current) {
+      return;
+    }
+    if (draftTimerRef.current) {
+      clearTimeout(draftTimerRef.current);
+    }
+    draftTimerRef.current = setTimeout(() => {
+      saveDraft("auto").catch(() => undefined);
+    }, 5000);
+    return () => {
+      if (draftTimerRef.current) {
+        clearTimeout(draftTimerRef.current);
+        draftTimerRef.current = null;
+      }
+    };
+  }, [buildCurrentDraftPayload, context?.machine?.tag, draftLoading, saveDraft]);
 
   /* ===== Derivados ===== */
   const hasNC = useMemo(() => Object.values(itemsState).some((i) => i.resultado === "NC"), [itemsState]);
@@ -162,6 +448,20 @@ export default function InspectionPage() {
     }
     return set;
   }, [context?.openIssues]);
+
+  const draftStatusMessage = useMemo(() => {
+    if (draftSaving) return "Salvando rascunho...";
+    if (autoSavingDraft) return "Salvando rascunho automaticamente...";
+    if (draftLoading) return "Carregando rascunho...";
+    if (lastDraftUpdatedAt) {
+      try {
+        return `Rascunho salvo em ${new Date(lastDraftUpdatedAt).toLocaleString("pt-BR")}`;
+      } catch {
+        return "Rascunho salvo.";
+      }
+    }
+    return "Rascunho automático ativo.";
+  }, [autoSavingDraft, draftLoading, draftSaving, lastDraftUpdatedAt]);
 
   /* ===== Handlers (mesmos nomes/contratos) ===== */
   const handleResultadoChange = useCallback((itemId: string, value: "C" | "NC" | "NA") => {
@@ -184,6 +484,22 @@ export default function InspectionPage() {
     setResolveIssues((prev) => ({ ...prev, [issueId]: checked }));
   }, []);
 
+  const handleSignatureEnd = useCallback(() => {
+    setSignatureTouched(true);
+    if (signatureRef.current?.isEmpty && signatureRef.current.isEmpty()) {
+      setSignatureDataUrl(null);
+      return;
+    }
+    if (signatureRef.current?.toDataURL) {
+      try {
+        const dataUrl = signatureRef.current.toDataURL("image/png");
+        setSignatureDataUrl(dataUrl);
+      } catch {
+        // ignore export errors
+      }
+    }
+  }, []);
+
   const submitInspection = useCallback(
     async (mode: "save" | "save-new") => {
       if (!context?.machine?.tag) { setFeedback({ type: "error", message: "Máquina sem TAG configurada." }); return; }
@@ -203,6 +519,8 @@ export default function InspectionPage() {
         let assinaturaDataUrl: string | undefined;
         if (signatureRef.current?.isEmpty && !signatureRef.current.isEmpty()) {
           assinaturaDataUrl = signatureRef.current.toDataURL("image/png");
+        } else if (signatureDataUrl) {
+          assinaturaDataUrl = signatureDataUrl;
         }
         const resolveIds = Object.entries(resolveIssues).filter(([, c]) => c).map(([id]) => id);
 
@@ -222,6 +540,16 @@ export default function InspectionPage() {
         const inspectionId = data?.id ? String(data.id) : null;
         if (inspectionId) setLastInspectionId(inspectionId);
 
+        await fetch(`/api/inspecoes/drafts/${encodeURIComponent(context.machine.tag)}`, { method: "DELETE" }).catch(() => undefined);
+        lastDraftPayloadRef.current = null;
+        setLastDraftUpdatedAt(null);
+        setDraftFeedback(null);
+        setDraftError(null);
+        if (draftTimerRef.current) {
+          clearTimeout(draftTimerRef.current);
+          draftTimerRef.current = null;
+        }
+
         refreshContext();
         if (mode === "save") {
           router.replace(`/inspecao/${encodeURIComponent(context.machine.tag)}?ok=1${inspectionId ? `&id=${inspectionId}` : ""}`);
@@ -235,7 +563,19 @@ export default function InspectionPage() {
         setFeedback({ type: "error", message: err instanceof Error && err.message ? err.message : "Falha ao salvar inspeção." });
       } finally { setSaving(false); setSavingAction(null); }
     },
-    [context, itemsState, observacoes, osNumero, refreshContext, resetForm, resolveIssues, router, saving, sortedItems]
+    [
+      context,
+      itemsState,
+      observacoes,
+      osNumero,
+      refreshContext,
+      resetForm,
+      resolveIssues,
+      router,
+      saving,
+      signatureDataUrl,
+      sortedItems,
+    ]
   );
 
   /* ===== Render ===== */
@@ -298,6 +638,22 @@ export default function InspectionPage() {
             {feedback.message}
           </div>
         )}
+        {draftFeedback && (
+          <div
+            className={`rounded-md border px-4 py-3 text-sm ${
+              draftFeedback.type === "success"
+                ? "border-blue-200 bg-blue-50 text-blue-700"
+                : "border-red-200 bg-red-50 text-red-700"
+            }`}
+          >
+            {draftFeedback.message}
+          </div>
+        )}
+        {draftError && !draftFeedback && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            {draftError}
+          </div>
+        )}
       </header>
 
       {/* Identificação da máquina (visual novo) */}
@@ -352,15 +708,22 @@ export default function InspectionPage() {
           <div className="h-40 w-full overflow-hidden rounded-md border border-dashed border-gray-300 bg-gray-50">
             {typeof window !== "undefined" && (
               <SignatureCanvas
-                ref={signatureRef} penColor="#111827" backgroundColor="transparent"
-                onEnd={() => setSignatureTouched(true)} canvasProps={{ className: "h-full w-full" }}
+                ref={signatureRef}
+                penColor="#111827"
+                backgroundColor="transparent"
+                onEnd={handleSignatureEnd}
+                canvasProps={{ className: "h-full w-full" }}
               />
             )}
           </div>
           <div className="flex items-center gap-3 text-sm">
             <button
               type="button"
-              onClick={() => { signatureRef.current?.clear?.(); setSignatureTouched(false); }}
+              onClick={() => {
+                signatureRef.current?.clear?.();
+                setSignatureTouched(false);
+                setSignatureDataUrl(null);
+              }}
               className="inline-flex items-center justify-center rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-600 transition hover:bg-gray-100"
             >
               Limpar assinatura
@@ -505,33 +868,51 @@ export default function InspectionPage() {
 
       {/* Footer fixo com ações (mesmo fluxo) */}
       <footer className="sticky bottom-0 left-0 right-0 z-10 -mx-4 border-t border-gray-200 bg-white/90 px-4 py-4 backdrop-blur">
-        <div className="mx-auto flex max-w-5xl flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="flex items-center gap-3">
+        <div className="mx-auto flex max-w-5xl flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="flex flex-col gap-2 text-sm text-gray-600">
             <a
               href={lastInspectionId ? `/api/inspecoes/${lastInspectionId}/pdf` : "#"}
-              target="_blank" rel="noreferrer"
-              className={`inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium transition ${
-                lastInspectionId ? "border-blue-600 bg-blue-50 text-blue-700 hover:bg-blue-100"
-                : "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
-              }`} aria-disabled={!lastInspectionId}>
+              target="_blank"
+              rel="noreferrer"
+              className={`inline-flex w-fit items-center justify-center rounded-md border px-4 py-2 text-sm font-medium transition ${
+                lastInspectionId
+                  ? "border-blue-600 bg-blue-50 text-blue-700 hover:bg-blue-100"
+                  : "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
+              }`}
+              aria-disabled={!lastInspectionId}
+            >
               Gerar PDF
             </a>
+            <p className="text-xs text-gray-500">{draftStatusMessage}</p>
+            <p className="text-xs text-gray-400">Fotos anexadas não são salvas nos rascunhos automáticos.</p>
           </div>
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <button
-              type="button" disabled={saving}
-              onClick={() => submitInspection("save")}
-              className="inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {saving && savingAction === "save" ? "Salvando..." : "Salvar"}
-            </button>
-            <button
-              type="button" disabled={saving}
-              onClick={() => submitInspection("save-new")}
-              className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {saving && savingAction === "save-new" ? "Salvando..." : "Salvar & Nova"}
-            </button>
+          <div className="flex flex-col gap-2 md:items-end">
+            <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:justify-end">
+              <button
+                type="button"
+                onClick={handleManualDraftSave}
+                disabled={draftSaving || saving || draftLoading}
+                className="inline-flex items-center justify-center rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {draftSaving ? "Salvando..." : "Salvar rascunho"}
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => submitInspection("save")}
+                className="inline-flex items-center justify-center rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {saving && savingAction === "save" ? "Salvando..." : "Salvar"}
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => submitInspection("save-new")}
+                className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {saving && savingAction === "save-new" ? "Salvando..." : "Salvar & Nova"}
+              </button>
+            </div>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- add API endpoints to list, update, and delete inspection drafts scoped to the logged-in maintainer
- enhance the inspection form with draft loading, auto/manual draft saves, and status messaging without changing the final submission flow
- surface in-progress inspection drafts on the maintainer home page via a horizontal carousel showing completion progress

## Testing
- npm run lint
- npm run typecheck
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ad1b2e248328a106f4e0745c27ee