### PR TITLE
Add pagination to admin machines list and support legacy machine lookups

### DIFF
--- a/src/app/admin/maquinas/page.tsx
+++ b/src/app/admin/maquinas/page.tsx
@@ -9,6 +9,8 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 
+const PAGE_SIZE = 25;
+
 interface MachineListItem {
   id: string;
   tag: string;
@@ -39,6 +41,7 @@ export default function MachinesPage() {
   const [machines, setMachines] = useState<MachineListItem[]>([]);
   const [templates, setTemplates] = useState<TemplateSummary[]>([]);
   const [query, setQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     let cancelled = false;
@@ -100,6 +103,25 @@ export default function MachinesPage() {
     });
   }, [machines, query]);
 
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [query]);
+
+  useEffect(() => {
+    setCurrentPage(prevPage => {
+      const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+      return prevPage > totalPages ? totalPages : prevPage;
+    });
+  }, [filtered.length]);
+
+  const goToPage = (page: number) => {
+    setCurrentPage(prevPage => {
+      const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+      const nextPage = Math.min(Math.max(page, 1), totalPages);
+      return nextPage === prevPage ? prevPage : nextPage;
+    });
+  };
+
   const content = () => {
     if (loading) {
       return (
@@ -125,36 +147,71 @@ export default function MachinesPage() {
       );
     }
 
+    const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+    const safePage = Math.max(1, Math.min(currentPage, totalPages));
+    const startIndex = (safePage - 1) * PAGE_SIZE;
+    const visibleMachines = filtered.slice(startIndex, startIndex + PAGE_SIZE);
+    const showingStart = visibleMachines.length > 0 ? startIndex + 1 : 0;
+    const showingEnd = startIndex + visibleMachines.length;
+
     return (
-      <div className="divide-y divide-[var(--border)] rounded-lg border border-[var(--border)]">
-        {filtered.map(machine => {
-          const templateLabel = machine.templateId ? templateMap.get(machine.templateId) ?? "-" : "-";
-          const createdLabel = machine.createdAt ? new Date(machine.createdAt).toLocaleString("pt-BR") : "-";
-          return (
-            <Link
-              key={machine.id}
-              href={`/admin/maquinas/${machine.id}`}
-              className="flex flex-col gap-3 p-4 transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
-            >
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <p className="text-base font-semibold text-[var(--text)]">{machine.tag} — {machine.nome}</p>
-                  <p className="text-xs text-[var(--muted)]">Template: {templateLabel}</p>
-                  <p className="text-xs text-[var(--muted)]">Criada em {createdLabel}</p>
+      <div className="space-y-4">
+        <div className="divide-y divide-[var(--border)] rounded-lg border border-[var(--border)]">
+          {visibleMachines.map(machine => {
+            const templateLabel = machine.templateId ? templateMap.get(machine.templateId) ?? "-" : "-";
+            const createdLabel = machine.createdAt ? new Date(machine.createdAt).toLocaleString("pt-BR") : "-";
+            return (
+              <Link
+                key={machine.id}
+                href={`/admin/maquinas/${machine.id}`}
+                className="flex flex-col gap-3 p-4 transition-colors hover:bg-[var(--surface-strong)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--primary)] focus-visible:ring-offset-2"
+              >
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="text-base font-semibold text-[var(--text)]">{machine.tag} — {machine.nome}</p>
+                    <p className="text-xs text-[var(--muted)]">Template: {templateLabel}</p>
+                    <p className="text-xs text-[var(--muted)]">Criada em {createdLabel}</p>
+                  </div>
+                  <span
+                    className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${
+                      machine.ativo
+                        ? "bg-emerald-100 text-emerald-700"
+                        : "bg-rose-100 text-rose-700"
+                    }`}
+                  >
+                    {machine.ativo ? "Ativa" : "Inativa"}
+                  </span>
                 </div>
-                <span
-                  className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium ${
-                    machine.ativo
-                      ? "bg-emerald-100 text-emerald-700"
-                      : "bg-rose-100 text-rose-700"
-                  }`}
-                >
-                  {machine.ativo ? "Ativa" : "Inativa"}
-                </span>
-              </div>
-            </Link>
-          );
-        })}
+              </Link>
+            );
+          })}
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-[var(--muted)]">
+            Mostrando {showingStart}–{showingEnd} de {filtered.length} máquinas
+          </p>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => goToPage(safePage - 1)}
+              disabled={safePage <= 1}
+              className={buttonStyles({ variant: "outline", size: "sm" })}
+            >
+              Anterior
+            </button>
+            <span className="text-sm text-[var(--muted)]">
+              Página {safePage} de {totalPages}
+            </span>
+            <button
+              type="button"
+              onClick={() => goToPage(safePage + 1)}
+              disabled={safePage >= totalPages}
+              className={buttonStyles({ variant: "outline", size: "sm" })}
+            >
+              Próxima
+            </button>
+          </div>
+        </div>
       </div>
     );
   };

--- a/src/app/api/maquinas/[id]/route.ts
+++ b/src/app/api/maquinas/[id]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { adminDb } from "@/lib/firebase-admin";
 import { requireAdminFromRequest } from "@/lib/guards";
 import { machineSchema } from "@/lib/machines-schema";
+import { findMachineByTag, resolveMachineDocumentById } from "@/lib/db/machines";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,13 +21,6 @@ function resolveId(params: Record<string, string | string[] | undefined>) {
   return Array.isArray(idValue) ? idValue[0] ?? null : idValue ?? null;
 }
 
-function mapMachine(doc: FirebaseFirestore.DocumentSnapshot) {
-  const data = doc.data() ?? {};
-  const record = { id: doc.id, ...data } as Record<string, unknown>;
-  delete record.id;
-  return { id: doc.id, ...record };
-}
-
 export async function GET(req: NextRequest, context: RouteContext) {
   const authorized = await requireAdminFromRequest(req);
   if (!authorized) {
@@ -41,11 +34,11 @@ export async function GET(req: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: "Missing id" }, { status: 400 });
     }
 
-    const doc = await adminDb.collection("machines").doc(id).get();
-    if (!doc.exists) {
+    const handle = await resolveMachineDocumentById(id);
+    if (!handle) {
       return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
     }
-    return NextResponse.json(mapMachine(doc));
+    return NextResponse.json(handle.data);
   } catch (err: unknown) {
     return NextResponse.json(
       { error: extractMessage(err, "INTERNAL_ERROR") },
@@ -66,9 +59,8 @@ export async function PUT(req: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
 
-  const docRef = adminDb.collection("machines").doc(id);
-  const snapshot = await docRef.get();
-  if (!snapshot.exists) {
+  const handle = await resolveMachineDocumentById(id);
+  if (!handle) {
     return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
   }
 
@@ -84,18 +76,14 @@ export async function PUT(req: NextRequest, context: RouteContext) {
   }
 
   try {
-    if (parsed.tag !== snapshot.data()?.tag) {
-      const duplicate = await adminDb
-        .collection("machines")
-        .where("tag", "==", parsed.tag)
-        .limit(1)
-        .get();
-      if (!duplicate.empty) {
+    if ((parsed.tag ?? "") !== (handle.data.tag ?? "")) {
+      const duplicate = await findMachineByTag(parsed.tag);
+      if (duplicate && duplicate.id !== id) {
         return NextResponse.json({ error: "TAG_DUPLICATE" }, { status: 409 });
       }
     }
 
-    await docRef.update({
+    await handle.ref.update({
       ...parsed,
       fotoUrl: parsed.fotoUrl ?? null,
     });
@@ -103,7 +91,7 @@ export async function PUT(req: NextRequest, context: RouteContext) {
     return NextResponse.json({
       id,
       ...parsed,
-      createdAt: snapshot.data()?.createdAt ?? null,
+      createdAt: handle.data.createdAt ?? null,
     });
   } catch (err: unknown) {
     return NextResponse.json(
@@ -126,7 +114,12 @@ export async function DELETE(req: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: "Missing id" }, { status: 400 });
     }
 
-    await adminDb.collection("machines").doc(id).delete();
+    const handle = await resolveMachineDocumentById(id);
+    if (!handle) {
+      return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+    }
+
+    await handle.ref.delete();
     return NextResponse.json({ ok: true });
   } catch (err: unknown) {
     return NextResponse.json(

--- a/src/app/api/maquinas/route.ts
+++ b/src/app/api/maquinas/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const q = req.nextUrl.searchParams.get("q")?.trim().toLowerCase();
-    const records = await listAllMachines(100);
+    const records = await listAllMachines();
 
     const filtered = q
       ? records.filter(item => {

--- a/src/lib/db/machines.ts
+++ b/src/lib/db/machines.ts
@@ -19,12 +19,54 @@ export type MachineDoc = {
   [key: string]: unknown;
 };
 
-function mapMachineDoc(docSnap: FirebaseFirestore.DocumentSnapshot): MachineDoc {
+export function mapMachineDoc(docSnap: FirebaseFirestore.DocumentSnapshot): MachineDoc {
   const data = docSnap.data() ?? {};
   const record: MachineDoc = { id: docSnap.id, ...data } as MachineDoc;
   delete (record as Record<string, unknown>).id;
   record.id = docSnap.id;
   return record;
+}
+
+export type MachineDocumentHandle = {
+  ref: FirebaseFirestore.DocumentReference;
+  snapshot: FirebaseFirestore.DocumentSnapshot;
+  collection: string;
+  data: MachineDoc;
+};
+
+async function fetchMachineSnapshotById(
+  collectionName: string,
+  id: string,
+): Promise<MachineDocumentHandle | null> {
+  const ref = adminDb.collection(collectionName).doc(id);
+  const snapshot = await ref.get();
+  if (!snapshot.exists) {
+    return null;
+  }
+
+  return {
+    ref,
+    snapshot,
+    collection: collectionName,
+    data: mapMachineDoc(snapshot),
+  };
+}
+
+export async function resolveMachineDocumentById(id: string): Promise<MachineDocumentHandle | null> {
+  const primaryHandle = await fetchMachineSnapshotById(PRIMARY_COLLECTION, id);
+  if (primaryHandle) {
+    return primaryHandle;
+  }
+
+  for (const legacyCollection of LEGACY_COLLECTIONS) {
+    const legacyHandle = await fetchMachineSnapshotById(legacyCollection, id);
+    if (legacyHandle) {
+      console.debug("[machines-repo] resolved legacy machine", { id, legacyCollection });
+      return legacyHandle;
+    }
+  }
+
+  return null;
 }
 
 function chunkIds(ids: string[], size = 10): string[][] {
@@ -217,34 +259,57 @@ export async function listActiveMachines(): Promise<MachineDoc[]> {
   return combined;
 }
 
-export async function listAllMachines(limit = 100): Promise<MachineDoc[]> {
-  const snapshot = await adminDb
-    .collection(PRIMARY_COLLECTION)
-    .orderBy("createdAt", "desc")
-    .limit(limit)
-    .get();
-
+async function fetchAllMachinesFromCollection(
+  collectionName: string,
+  batchSize = 500,
+): Promise<MachineDoc[]> {
   const records: MachineDoc[] = [];
-  snapshot.forEach(docSnap => {
-    records.push(mapMachineDoc(docSnap));
-  });
+  let lastDoc: FirebaseFirestore.QueryDocumentSnapshot | null = null;
 
-  if (records.length < limit) {
-    for (const legacyCollection of LEGACY_COLLECTIONS) {
-      const legacySnapshot = await adminDb
-        .collection(legacyCollection)
-        .orderBy("createdAt", "desc")
-        .limit(limit)
-        .get();
+  while (true) {
+    let query = adminDb
+      .collection(collectionName)
+      .orderBy("createdAt", "desc")
+      .limit(batchSize);
 
-      legacySnapshot.forEach(docSnap => {
-        const record = mapMachineDoc(docSnap);
-        if (!records.some(item => item.id === record.id)) {
-          records.push(record);
-        }
-      });
+    if (lastDoc) {
+      query = query.startAfter(lastDoc);
+    }
+
+    const snapshot = await query.get();
+    if (snapshot.empty) {
+      break;
+    }
+
+    snapshot.forEach(docSnap => {
+      records.push(mapMachineDoc(docSnap));
+    });
+
+    const docs = snapshot.docs;
+    lastDoc = docs[docs.length - 1] ?? null;
+
+    if (docs.length < batchSize || !lastDoc) {
+      break;
     }
   }
 
   return records;
+}
+
+export async function listAllMachines(batchSize = 500): Promise<MachineDoc[]> {
+  const primaryRecords = await fetchAllMachinesFromCollection(PRIMARY_COLLECTION, batchSize);
+  const combined = [...primaryRecords];
+  const seenIds = new Set(primaryRecords.map(record => record.id));
+
+  for (const legacyCollection of LEGACY_COLLECTIONS) {
+    const legacyRecords = await fetchAllMachinesFromCollection(legacyCollection, batchSize);
+    for (const record of legacyRecords) {
+      if (!seenIds.has(record.id)) {
+        combined.push(record);
+        seenIds.add(record.id);
+      }
+    }
+  }
+
+  return combined;
 }


### PR DESCRIPTION
## Summary
- add client-side pagination on the admin machines page to show 25 records per page
- fetch all machine records from Firestore so the list is no longer capped at 100 entries
- allow machine API routes to resolve records stored in legacy collections when editing or deleting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d5ecda9883288aa6313588925309