### PR TITLE
Merge/dedupe stored images, unify answers source, and improve machine filter UI

### DIFF
--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -143,34 +143,26 @@ function dedupeAnswers(answers: ChecklistAnswer[]) {
   return unique;
 }
 
+function mergeStoredImageCollections(...collections: unknown[]): StoredImage[] {
+  const seen = new Set<string>();
+  const merged: StoredImage[] = [];
+  collections.forEach(collection => {
+    normalizeStoredImages(collection).forEach(image => {
+      const key = `${image.provider}:${image.url}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      merged.push(image);
+    });
+  });
+  return merged;
+}
+
 function normalizeAnswers(
   data: Record<string, unknown>,
   templateItems: Map<string, TemplateItemData>
 ): ChecklistAnswer[] {
-  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
-  if (answers.length > 0) {
-    return dedupeAnswers(
-      answers
-        .filter(item => item?.questionId)
-        .map(item => ({
-          questionId: item.questionId,
-          questionText:
-            item.questionText ||
-            templateItems.get(item.questionId)?.oQueChecar ||
-            templateItems.get(item.questionId)?.criterio ||
-            templateItems.get(item.questionId)?.componente ||
-            `Item ${item.questionId}`,
-          response: item.response === "nc" || item.response === "na" ? item.response : "c",
-          observation: item.observation ?? null,
-          photoUrls: normalizeStoredImages(item.photoUrls ?? []),
-          recurrence: item.recurrence === true,
-          itemOsNumero: item.itemOsNumero ?? null,
-        }))
-    );
-  }
-
   const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
-  return dedupeAnswers(
+  const answersFromItens = dedupeAnswers(
     itens
       .filter(item => item?.templateItemId)
       .map(item => {
@@ -195,6 +187,41 @@ function normalizeAnswers(
         } satisfies ChecklistAnswer;
       })
   );
+
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length === 0) {
+    return answersFromItens;
+  }
+
+  const answersFromItensByQuestionId = new Map(
+    answersFromItens.map(answer => [answer.questionId, answer] as const)
+  );
+  const answersFromPayload = dedupeAnswers(
+    answers
+      .filter(item => item?.questionId)
+      .map(item => {
+        const fallbackFromItens = answersFromItensByQuestionId.get(item.questionId);
+        return {
+          questionId: item.questionId,
+          questionText:
+            item.questionText ||
+            templateItems.get(item.questionId)?.oQueChecar ||
+            templateItems.get(item.questionId)?.criterio ||
+            templateItems.get(item.questionId)?.componente ||
+            fallbackFromItens?.questionText ||
+            `Item ${item.questionId}`,
+          response: item.response === "nc" || item.response === "na" ? item.response : "c",
+          observation: item.observation ?? fallbackFromItens?.observation ?? null,
+          photoUrls: mergeStoredImageCollections(item.photoUrls, fallbackFromItens?.photoUrls),
+          recurrence: item.recurrence === true || fallbackFromItens?.recurrence === true,
+          itemOsNumero: item.itemOsNumero ?? fallbackFromItens?.itemOsNumero ?? null,
+        } satisfies ChecklistAnswer;
+      })
+  );
+
+  const questionIdsFromPayload = new Set(answersFromPayload.map(item => item.questionId));
+  const missingFromPayload = answersFromItens.filter(item => !questionIdsFromPayload.has(item.questionId));
+  return dedupeAnswers([...answersFromPayload, ...missingFromPayload]);
 }
 
 function buildMachineLabel(machine: Record<string, unknown>) {
@@ -227,9 +254,8 @@ export default function AdminNonConformitiesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<NonConformityItem[]>([]);
-  const [machines, setMachines] = useState<MachineOption[]>([]);
   const [treatmentsByResponse, setTreatmentsByResponse] = useState<Record<string, ChecklistNonConformityTreatment[]>>({});
-  const [machineFilter, setMachineFilter] = useState("all");
+  const [machineFilter, setMachineFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [savingId, setSavingId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Record<string, FeedbackState>>({});
@@ -461,7 +487,7 @@ export default function AdminNonConformitiesPage() {
             typeof issueData.descricao === "string"
               ? issueData.descricao
               : answerData?.observation ?? null,
-          photos: normalizeStoredImages(issueData.fotos ?? answerData?.photoUrls ?? []),
+          photos: mergeStoredImageCollections(issueData.fotos, answerData?.photoUrls),
           itemOsNumero:
             typeof issueData.osNumero === "string"
               ? issueData.osNumero
@@ -479,7 +505,6 @@ export default function AdminNonConformitiesPage() {
         });
       });
 
-      setMachines(machineOptions);
       setItems(sortByLastActivityDesc(builtItems));
       setTreatmentsByResponse(treatmentsRecord);
     } catch (err: unknown) {
@@ -494,10 +519,26 @@ export default function AdminNonConformitiesPage() {
     loadData();
   }, [loadData]);
 
+  const machineOptionsForFilter = useMemo(() => {
+    return Array.from(new Set(items.map(item => item.machineLabel.trim()).filter(Boolean))).sort((a, b) =>
+      a.localeCompare(b, "pt-BR")
+    );
+  }, [items]);
+
   const filteredItems = useMemo(() => {
+    const machineSearch = machineFilter.trim().toLowerCase();
     return items.filter(item => {
-      if (machineFilter !== "all" && item.machineId !== machineFilter) {
-        return false;
+      if (machineSearch) {
+        const machineLabel = item.machineLabel.toLowerCase();
+        const machineTag = (item.machineTag ?? "").toLowerCase();
+        const machineId = (item.machineId ?? "").toLowerCase();
+        if (
+          !machineLabel.includes(machineSearch) &&
+          !machineTag.includes(machineSearch) &&
+          !machineId.includes(machineSearch)
+        ) {
+          return false;
+        }
       }
       if (statusFilter === "pending") {
         return item.status !== "resolved";
@@ -724,16 +765,18 @@ export default function AdminNonConformitiesPage() {
         <CardContent className="grid gap-4 md:grid-cols-2">
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Máquina</span>
-            <Select value={machineFilter} onChange={event => setMachineFilter(event.target.value)}>
-              <option value="all">Todas</option>
-              {machines
-                .filter(machine => machine.ativo !== false)
-                .map(machine => (
-                  <option key={machine.id} value={machine.id}>
-                    {machine.tag ? `${machine.nome} (${machine.tag})` : machine.nome}
-                  </option>
-                ))}
-            </Select>
+            <Input
+              type="text"
+              value={machineFilter}
+              onChange={event => setMachineFilter(event.target.value)}
+              list="machine-filter-options"
+              placeholder="Digite nome, tag ou ID"
+            />
+            <datalist id="machine-filter-options">
+              {machineOptionsForFilter.map(option => (
+                <option key={option} value={option} />
+              ))}
+            </datalist>
           </label>
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Status</span>

--- a/src/app/api/inspecoes/[id]/fotos/route.ts
+++ b/src/app/api/inspecoes/[id]/fotos/route.ts
@@ -7,6 +7,7 @@ import { requireMaint } from "@/lib/guards";
 import { fromDataUrl } from "@/lib/storage/dataUrl";
 import { normalizeStoredImages } from "@/lib/storage/images";
 import { r2Provider } from "@/lib/storage/r2Provider";
+import type { StoredImage } from "@/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,6 +33,20 @@ function buildUploadName(prefixes: Array<string | null | undefined>) {
     .filter(Boolean);
   const base = parts.join("-") || "inspecao";
   return `${base}-${randomUUID()}`.slice(0, 100);
+}
+
+function mergeStoredImageCollections(...collections: unknown[]) {
+  const seen = new Set<string>();
+  const merged: StoredImage[] = [];
+  collections.forEach(collection => {
+    normalizeStoredImages(collection).forEach(image => {
+      const dedupeKey = `${image.provider}:${image.url}`;
+      if (seen.has(dedupeKey)) return;
+      seen.add(dedupeKey);
+      merged.push(image);
+    });
+  });
+  return merged.slice(0, 3);
 }
 
 type RouteContext = { params: Promise<{ id?: string }> };
@@ -86,7 +101,7 @@ export async function POST(req: NextRequest, context: RouteContext) {
 
     const itensArray = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
     const updatedItens = itensArray.map(item => {
-      if (item.templateItemId !== payload.templateItemId) return item;
+      if (String(item.templateItemId ?? "") !== payload.templateItemId) return item;
       const fotos = normalizeStoredImages(item.fotos ?? []);
       const nextFotos = [...fotos, storedImage].slice(0, 3);
       return { ...item, fotos: nextFotos };
@@ -96,7 +111,7 @@ export async function POST(req: NextRequest, context: RouteContext) {
       ? (data.answers as Array<Record<string, unknown>>)
       : [];
     const updatedAnswers = answersArray.map(answer => {
-      if (answer.questionId !== payload.templateItemId) return answer;
+      if (String(answer.questionId ?? "") !== payload.templateItemId) return answer;
       const photoUrls = normalizeStoredImages(answer.photoUrls ?? []);
       const nextPhotoUrls = [...photoUrls, storedImage].slice(0, 3);
       return { ...answer, photoUrls: nextPhotoUrls };
@@ -106,19 +121,21 @@ export async function POST(req: NextRequest, context: RouteContext) {
 
     const machineId = (data.machine as { machineId?: string } | undefined)?.machineId;
     if (machineId) {
-      const openIssuesSnap = await adminDb
+      const issuesSnap = await adminDb
         .collection("issues")
         .where("machineId", "==", machineId)
         .where("templateItemId", "==", payload.templateItemId)
-        .where("status", "in", ["aberta", "concluida"])
         .get();
 
       await Promise.all(
-        openIssuesSnap.docs.map(async doc => {
-          const issueData = doc.data() ?? {};
-          const fotos = normalizeStoredImages(issueData.fotos ?? []);
-          const nextFotos = [...fotos, storedImage].slice(0, 3);
-          await doc.ref.update({ fotos: nextFotos });
+        issuesSnap.docs.map(async doc => {
+          await adminDb.runTransaction(async transaction => {
+            const issueSnap = await transaction.get(doc.ref);
+            if (!issueSnap.exists) return;
+            const issueData = issueSnap.data() ?? {};
+            const nextFotos = mergeStoredImageCollections(issueData.fotos, [storedImage]);
+            transaction.update(doc.ref, { fotos: nextFotos });
+          });
         })
       );
     }
@@ -130,4 +147,3 @@ export async function POST(req: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
-


### PR DESCRIPTION
### Motivation
- Ensure photo lists are deduplicated and bounded when merging images from multiple sources to avoid duplicates and oversized arrays.
- Combine legacy `itens` data with newer `answers` payloads so checklist answers are normalized with sensible fallbacks and preserved fields.
- Make machine filtering more flexible by allowing free-text search by name, tag or ID instead of a fixed select list.

### Description
- Added `mergeStoredImageCollections` helper in both `page.tsx` and the upload route to deduplicate stored images by `provider:url` and cap merged results where appropriate. 
- Rewrote `normalizeAnswers` to build answers from `itens`, then overlay/merge incoming `answers` using fallbacks for `questionText`, `observation`, `photoUrls`, `recurrence`, and `itemOsNumero`, and to dedupe final answers.
- Switched item photo assembly to use the new merge helper when building non-conformity list entries (`photos: mergeStoredImageCollections(...)`).
- Reworked the inspection photo upload route to use safe string comparisons for IDs, run updates to matching issues inside a transaction, and update issue photos using the merging helper.
- Replaced the machines `Select` with a free-text `Input` plus `datalist`, removed the `machines` state, added `machineOptionsForFilter`, and changed `machineFilter` default to an empty string with substring matching against `machineLabel`, `machineTag`, and `machineId`.

### Testing
- Performed a TypeScript build with `yarn build` which completed successfully.
- Ran the project test suite with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c414fca1c88330bc5e5f3bbb9c4ed2)