### PR TITLE
Merge/normalize inspection answers and photos; handle legacy `itens`; improve NC filters

### DIFF
--- a/src/app/admin/inspecoes/[id]/edit/page.tsx
+++ b/src/app/admin/inspecoes/[id]/edit/page.tsx
@@ -36,6 +36,7 @@ interface ApiAnswer {
 interface ApiInspection {
   id: string;
   answers?: ApiAnswer[];
+  itens?: Array<Record<string, unknown>>;
   observacoes?: string | null;
   osNumero?: string | null;
   createdAt?: string | null;
@@ -134,6 +135,20 @@ function readFileAsDataUrl(file: File) {
   });
 }
 
+function mergeStoredImageCollections(...collections: unknown[]): StoredImage[] {
+  const seen = new Set<string>();
+  const merged: StoredImage[] = [];
+  collections.forEach(collection => {
+    normalizeStoredImages(collection).forEach(image => {
+      const dedupeKey = `${image.provider ?? "imgbb"}:${image.url}`;
+      if (seen.has(dedupeKey)) return;
+      seen.add(dedupeKey);
+      merged.push(image);
+    });
+  });
+  return merged;
+}
+
 export default function EditInspectionPage() {
   const params = useParams();
   const idParam = normalizeId(params?.id as string | string[] | undefined);
@@ -177,6 +192,7 @@ export default function EditInspectionPage() {
       const template = data.template ?? null;
       const machineData = inspection.machine ?? data.machine ?? null;
       const answers = Array.isArray(inspection.answers) ? inspection.answers : [];
+      const itens = Array.isArray(inspection.itens) ? inspection.itens : [];
 
       const templateItems = Array.isArray(template?.itens) ? template.itens : [];
       const templateMap = new Map<string, TemplateItemData>();
@@ -188,12 +204,21 @@ export default function EditInspectionPage() {
       answers.forEach(answer => {
         if (answer?.questionId) answersMap.set(answer.questionId, answer);
       });
+      const itensMap = new Map<string, Record<string, unknown>>();
+      itens.forEach(item => {
+        const templateItemId = typeof item?.templateItemId === "string" ? item.templateItemId : null;
+        if (templateItemId) itensMap.set(templateItemId, item);
+      });
 
       const formItems: FormItem[] = templateItems.map((item, index) => {
-        const answer = item.id ? answersMap.get(String(item.id)) : undefined;
-        const response = answer?.response ?? "c";
+        const questionId = item.id ? String(item.id) : `template-${index}`;
+        const answer = item.id ? answersMap.get(questionId) : undefined;
+        const itemData = item.id ? itensMap.get(questionId) : undefined;
+        const rawResultado = typeof itemData?.resultado === "string" ? itemData.resultado.toLowerCase() : null;
+        const responseFromItem: "c" | "nc" | "na" = rawResultado === "nc" ? "nc" : rawResultado === "na" ? "na" : "c";
+        const response = answer?.response ?? responseFromItem;
         return {
-          questionId: item.id ? String(item.id) : `template-${index}`,
+          questionId,
           questionText:
             answer?.questionText ||
             item.oQueChecar ||
@@ -208,15 +233,22 @@ export default function EditInspectionPage() {
           order: typeof item.ordem === "number" ? item.ordem : index,
           previousResponse: response,
           response,
-          observation: answer?.observation ?? "",
-          itemOsNumero: answer?.itemOsNumero ? String(answer.itemOsNumero).toUpperCase() : "",
-          existingPhotos: normalizeStoredImages(answer?.photoUrls ?? []),
+          observation:
+            answer?.observation ??
+            (typeof itemData?.observacaoItem === "string" ? itemData.observacaoItem : ""),
+          itemOsNumero: answer?.itemOsNumero
+            ? String(answer.itemOsNumero).toUpperCase()
+            : typeof itemData?.osNumeroItem === "string"
+            ? itemData.osNumeroItem.toUpperCase()
+            : "",
+          existingPhotos: mergeStoredImageCollections(answer?.photoUrls, itemData?.fotos),
           newPhotos: [],
         };
       });
 
       answers.forEach(answer => {
         if (answer?.questionId && !templateMap.has(answer.questionId)) {
+          const itemData = itensMap.get(answer.questionId);
           formItems.push({
             questionId: answer.questionId,
             questionText: answer.questionText ?? `Item ${answer.questionId}`,
@@ -228,12 +260,41 @@ export default function EditInspectionPage() {
             order: Number.MAX_SAFE_INTEGER,
             previousResponse: answer.response,
             response: answer.response,
-            observation: answer.observation ?? "",
-            itemOsNumero: answer.itemOsNumero ? String(answer.itemOsNumero).toUpperCase() : "",
-            existingPhotos: normalizeStoredImages(answer.photoUrls ?? []),
+            observation:
+              answer.observation ??
+              (typeof itemData?.observacaoItem === "string" ? itemData.observacaoItem : ""),
+            itemOsNumero: answer.itemOsNumero
+              ? String(answer.itemOsNumero).toUpperCase()
+              : typeof itemData?.osNumeroItem === "string"
+              ? itemData.osNumeroItem.toUpperCase()
+              : "",
+            existingPhotos: mergeStoredImageCollections(answer.photoUrls, itemData?.fotos),
             newPhotos: [],
           });
         }
+      });
+
+      itens.forEach(item => {
+        const questionId = typeof item?.templateItemId === "string" ? item.templateItemId : null;
+        if (!questionId || answersMap.has(questionId) || templateMap.has(questionId)) return;
+        const rawResultado = typeof item.resultado === "string" ? item.resultado.toLowerCase() : null;
+        const response: "c" | "nc" | "na" = rawResultado === "nc" ? "nc" : rawResultado === "na" ? "na" : "c";
+        formItems.push({
+          questionId,
+          questionText: `Item ${questionId}`,
+          componente: undefined,
+          oQueChecar: undefined,
+          instrumento: undefined,
+          criterio: undefined,
+          oQueFazer: undefined,
+          order: Number.MAX_SAFE_INTEGER,
+          previousResponse: response,
+          response,
+          observation: typeof item.observacaoItem === "string" ? item.observacaoItem : "",
+          itemOsNumero: typeof item.osNumeroItem === "string" ? item.osNumeroItem.toUpperCase() : "",
+          existingPhotos: mergeStoredImageCollections(item.fotos),
+          newPhotos: [],
+        });
       });
 
       formItems.sort((a, b) => a.order - b.order);

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -143,34 +143,26 @@ function dedupeAnswers(answers: ChecklistAnswer[]) {
   return unique;
 }
 
+function mergeStoredImageCollections(...collections: unknown[]): StoredImage[] {
+  const seen = new Set<string>();
+  const merged: StoredImage[] = [];
+  collections.forEach(collection => {
+    normalizeStoredImages(collection).forEach(image => {
+      const key = `${image.provider}:${image.url}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      merged.push(image);
+    });
+  });
+  return merged;
+}
+
 function normalizeAnswers(
   data: Record<string, unknown>,
   templateItems: Map<string, TemplateItemData>
 ): ChecklistAnswer[] {
-  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
-  if (answers.length > 0) {
-    return dedupeAnswers(
-      answers
-        .filter(item => item?.questionId)
-        .map(item => ({
-          questionId: item.questionId,
-          questionText:
-            item.questionText ||
-            templateItems.get(item.questionId)?.oQueChecar ||
-            templateItems.get(item.questionId)?.criterio ||
-            templateItems.get(item.questionId)?.componente ||
-            `Item ${item.questionId}`,
-          response: item.response === "nc" || item.response === "na" ? item.response : "c",
-          observation: item.observation ?? null,
-          photoUrls: normalizeStoredImages(item.photoUrls ?? []),
-          recurrence: item.recurrence === true,
-          itemOsNumero: item.itemOsNumero ?? null,
-        }))
-    );
-  }
-
   const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
-  return dedupeAnswers(
+  const answersFromItens = dedupeAnswers(
     itens
       .filter(item => item?.templateItemId)
       .map(item => {
@@ -195,6 +187,41 @@ function normalizeAnswers(
         } satisfies ChecklistAnswer;
       })
   );
+
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length === 0) {
+    return answersFromItens;
+  }
+
+  const answersFromItensByQuestionId = new Map(
+    answersFromItens.map(answer => [answer.questionId, answer] as const)
+  );
+  const answersFromPayload = dedupeAnswers(
+    answers
+      .filter(item => item?.questionId)
+      .map(item => {
+        const fallbackFromItens = answersFromItensByQuestionId.get(item.questionId);
+        return {
+          questionId: item.questionId,
+          questionText:
+            item.questionText ||
+            templateItems.get(item.questionId)?.oQueChecar ||
+            templateItems.get(item.questionId)?.criterio ||
+            templateItems.get(item.questionId)?.componente ||
+            fallbackFromItens?.questionText ||
+            `Item ${item.questionId}`,
+          response: item.response === "nc" || item.response === "na" ? item.response : "c",
+          observation: item.observation ?? fallbackFromItens?.observation ?? null,
+          photoUrls: mergeStoredImageCollections(item.photoUrls, fallbackFromItens?.photoUrls),
+          recurrence: item.recurrence === true || fallbackFromItens?.recurrence === true,
+          itemOsNumero: item.itemOsNumero ?? fallbackFromItens?.itemOsNumero ?? null,
+        } satisfies ChecklistAnswer;
+      })
+  );
+
+  const questionIdsFromPayload = new Set(answersFromPayload.map(item => item.questionId));
+  const missingFromPayload = answersFromItens.filter(item => !questionIdsFromPayload.has(item.questionId));
+  return dedupeAnswers([...answersFromPayload, ...missingFromPayload]);
 }
 
 function buildMachineLabel(machine: Record<string, unknown>) {
@@ -227,9 +254,8 @@ export default function AdminNonConformitiesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<NonConformityItem[]>([]);
-  const [machines, setMachines] = useState<MachineOption[]>([]);
   const [treatmentsByResponse, setTreatmentsByResponse] = useState<Record<string, ChecklistNonConformityTreatment[]>>({});
-  const [machineFilter, setMachineFilter] = useState("all");
+  const [machineFilter, setMachineFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [savingId, setSavingId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Record<string, FeedbackState>>({});
@@ -461,7 +487,7 @@ export default function AdminNonConformitiesPage() {
             typeof issueData.descricao === "string"
               ? issueData.descricao
               : answerData?.observation ?? null,
-          photos: normalizeStoredImages(issueData.fotos ?? answerData?.photoUrls ?? []),
+          photos: mergeStoredImageCollections(issueData.fotos, answerData?.photoUrls),
           itemOsNumero:
             typeof issueData.osNumero === "string"
               ? issueData.osNumero
@@ -479,7 +505,6 @@ export default function AdminNonConformitiesPage() {
         });
       });
 
-      setMachines(machineOptions);
       setItems(sortByLastActivityDesc(builtItems));
       setTreatmentsByResponse(treatmentsRecord);
     } catch (err: unknown) {
@@ -494,10 +519,26 @@ export default function AdminNonConformitiesPage() {
     loadData();
   }, [loadData]);
 
+  const machineOptionsForFilter = useMemo(() => {
+    return Array.from(new Set(items.map(item => item.machineLabel.trim()).filter(Boolean))).sort((a, b) =>
+      a.localeCompare(b, "pt-BR")
+    );
+  }, [items]);
+
   const filteredItems = useMemo(() => {
+    const machineSearch = machineFilter.trim().toLowerCase();
     return items.filter(item => {
-      if (machineFilter !== "all" && item.machineId !== machineFilter) {
-        return false;
+      if (machineSearch) {
+        const machineLabel = item.machineLabel.toLowerCase();
+        const machineTag = (item.machineTag ?? "").toLowerCase();
+        const machineId = (item.machineId ?? "").toLowerCase();
+        if (
+          !machineLabel.includes(machineSearch) &&
+          !machineTag.includes(machineSearch) &&
+          !machineId.includes(machineSearch)
+        ) {
+          return false;
+        }
       }
       if (statusFilter === "pending") {
         return item.status !== "resolved";
@@ -724,16 +765,18 @@ export default function AdminNonConformitiesPage() {
         <CardContent className="grid gap-4 md:grid-cols-2">
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Máquina</span>
-            <Select value={machineFilter} onChange={event => setMachineFilter(event.target.value)}>
-              <option value="all">Todas</option>
-              {machines
-                .filter(machine => machine.ativo !== false)
-                .map(machine => (
-                  <option key={machine.id} value={machine.id}>
-                    {machine.tag ? `${machine.nome} (${machine.tag})` : machine.nome}
-                  </option>
-                ))}
-            </Select>
+            <Input
+              type="text"
+              value={machineFilter}
+              onChange={event => setMachineFilter(event.target.value)}
+              list="machine-filter-options"
+              placeholder="Digite nome, tag ou ID"
+            />
+            <datalist id="machine-filter-options">
+              {machineOptionsForFilter.map(option => (
+                <option key={option} value={option} />
+              ))}
+            </datalist>
           </label>
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Status</span>

--- a/src/app/api/inspecoes/[id]/fotos/route.ts
+++ b/src/app/api/inspecoes/[id]/fotos/route.ts
@@ -7,6 +7,7 @@ import { requireMaint } from "@/lib/guards";
 import { fromDataUrl } from "@/lib/storage/dataUrl";
 import { normalizeStoredImages } from "@/lib/storage/images";
 import { r2Provider } from "@/lib/storage/r2Provider";
+import type { StoredImage } from "@/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -32,6 +33,20 @@ function buildUploadName(prefixes: Array<string | null | undefined>) {
     .filter(Boolean);
   const base = parts.join("-") || "inspecao";
   return `${base}-${randomUUID()}`.slice(0, 100);
+}
+
+function mergeStoredImageCollections(...collections: unknown[]) {
+  const seen = new Set<string>();
+  const merged: StoredImage[] = [];
+  collections.forEach(collection => {
+    normalizeStoredImages(collection).forEach(image => {
+      const dedupeKey = `${image.provider}:${image.url}`;
+      if (seen.has(dedupeKey)) return;
+      seen.add(dedupeKey);
+      merged.push(image);
+    });
+  });
+  return merged.slice(0, 3);
 }
 
 type RouteContext = { params: Promise<{ id?: string }> };
@@ -85,40 +100,56 @@ export async function POST(req: NextRequest, context: RouteContext) {
     } as const;
 
     const itensArray = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+    let itensUpdated = false;
     const updatedItens = itensArray.map(item => {
-      if (item.templateItemId !== payload.templateItemId) return item;
+      if (String(item.templateItemId ?? "") !== payload.templateItemId) return item;
+      itensUpdated = true;
       const fotos = normalizeStoredImages(item.fotos ?? []);
       const nextFotos = [...fotos, storedImage].slice(0, 3);
       return { ...item, fotos: nextFotos };
     });
+    if (!itensUpdated) {
+      updatedItens.push({ templateItemId: payload.templateItemId, resultado: "NC", fotos: [storedImage] });
+    }
 
     const answersArray = Array.isArray(data.answers)
       ? (data.answers as Array<Record<string, unknown>>)
       : [];
+    let answersUpdated = false;
     const updatedAnswers = answersArray.map(answer => {
-      if (answer.questionId !== payload.templateItemId) return answer;
+      if (String(answer.questionId ?? "") !== payload.templateItemId) return answer;
+      answersUpdated = true;
       const photoUrls = normalizeStoredImages(answer.photoUrls ?? []);
       const nextPhotoUrls = [...photoUrls, storedImage].slice(0, 3);
       return { ...answer, photoUrls: nextPhotoUrls };
     });
+    if (!answersUpdated) {
+      updatedAnswers.push({
+        questionId: payload.templateItemId,
+        response: "nc",
+        photoUrls: [storedImage],
+      });
+    }
 
     await docRef.update({ itens: updatedItens, answers: updatedAnswers });
 
     const machineId = (data.machine as { machineId?: string } | undefined)?.machineId;
     if (machineId) {
-      const openIssuesSnap = await adminDb
+      const issuesSnap = await adminDb
         .collection("issues")
         .where("machineId", "==", machineId)
         .where("templateItemId", "==", payload.templateItemId)
-        .where("status", "in", ["aberta", "concluida"])
         .get();
 
       await Promise.all(
-        openIssuesSnap.docs.map(async doc => {
-          const issueData = doc.data() ?? {};
-          const fotos = normalizeStoredImages(issueData.fotos ?? []);
-          const nextFotos = [...fotos, storedImage].slice(0, 3);
-          await doc.ref.update({ fotos: nextFotos });
+        issuesSnap.docs.map(async doc => {
+          await adminDb.runTransaction(async transaction => {
+            const issueSnap = await transaction.get(doc.ref);
+            if (!issueSnap.exists) return;
+            const issueData = issueSnap.data() ?? {};
+            const nextFotos = mergeStoredImageCollections(issueData.fotos, [storedImage]);
+            transaction.update(doc.ref, { fotos: nextFotos });
+          });
         })
       );
     }
@@ -130,4 +161,3 @@ export async function POST(req: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
-

--- a/src/app/api/inspecoes/[id]/route.ts
+++ b/src/app/api/inspecoes/[id]/route.ts
@@ -4,6 +4,7 @@ import { adminDb } from "@/lib/firebase-admin";
 import { requireAdminFromRequest, requireMaint } from "@/lib/guards";
 import { fromDataUrl } from "@/lib/storage/dataUrl";
 import { normalizeStoredImages } from "@/lib/storage/images";
+import { normalizeInspectionAnswers } from "@/lib/storage/inspection-answers";
 import { r2Provider } from "@/lib/storage/r2Provider";
 import type {
   ChecklistAnswer,
@@ -68,49 +69,7 @@ function resolveId(params: Record<string, string | string[] | undefined>) {
 }
 
 function normalizeAnswers(data: Record<string, unknown>, templateItemsMap: Map<string, TemplateItem>) {
-  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
-  if (answers.length > 0) {
-    return answers
-      .filter(item => item?.questionId)
-      .map(item => ({
-        questionId: item.questionId,
-        questionText:
-          item.questionText ??
-          templateItemsMap.get(item.questionId)?.oQueChecar ??
-          templateItemsMap.get(item.questionId)?.criterio ??
-          null,
-        response: item.response === "nc" || item.response === "na" ? item.response : "c",
-        observation: item.observation ?? null,
-        photoUrls: normalizeStoredImages(
-          (item as unknown as Record<string, unknown>).photoUrls ??
-            (item as unknown as Record<string, unknown>).photos ??
-            []
-        ),
-        recurrence: item.recurrence ?? false,
-        itemOsNumero: item.itemOsNumero ?? null,
-      }));
-  }
-
-  const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
-  return itens
-    .filter(item => item?.templateItemId)
-    .map(item => {
-      const questionId = String(item.templateItemId);
-      const templateItem = templateItemsMap.get(questionId) ?? {};
-      const resultado = String(item.resultado || "C").toLowerCase();
-      const response: "c" | "nc" | "na" = resultado === "nc" ? "nc" : resultado === "na" ? "na" : "c";
-      return {
-        questionId,
-        questionText: templateItem.oQueChecar ?? templateItem.criterio ?? (typeof item.componente === "string" ? item.componente : null),
-        response,
-        observation: typeof item.observacaoItem === "string" ? item.observacaoItem : null,
-        photoUrls: normalizeStoredImages(item.fotos ?? []),
-        recurrence: false,
-        itemOsNumero: typeof item.osNumeroItem === "string" && item.osNumeroItem.trim()
-          ? item.osNumeroItem.trim().toUpperCase()
-          : null,
-      } satisfies ChecklistAnswer;
-    });
+  return normalizeInspectionAnswers(data, templateItemsMap);
 }
 
 function mapTemplateItems(templateData: Record<string, unknown>) {

--- a/src/lib/storage/inspection-answers.ts
+++ b/src/lib/storage/inspection-answers.ts
@@ -1,0 +1,80 @@
+import type { ChecklistAnswer, StoredImage } from "../../types/index.ts";
+import { normalizeStoredImages } from "./images.ts";
+
+type TemplateItem = {
+  oQueChecar?: string;
+  criterio?: string;
+};
+
+export function mergeStoredImageCollections(...collections: unknown[]): StoredImage[] {
+  const seen = new Set<string>();
+  const merged: StoredImage[] = [];
+  collections.forEach(collection => {
+    normalizeStoredImages(collection).forEach(image => {
+      const dedupeKey = `${image.provider ?? "imgbb"}:${image.url}`;
+      if (seen.has(dedupeKey)) return;
+      seen.add(dedupeKey);
+      merged.push(image);
+    });
+  });
+  return merged;
+}
+
+export function normalizeInspectionAnswers(
+  data: Record<string, unknown>,
+  templateItemsMap: Map<string, TemplateItem>
+): ChecklistAnswer[] {
+  const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  const itensMap = new Map<string, ChecklistAnswer>();
+  itens
+    .filter(item => item?.templateItemId)
+    .forEach(item => {
+      const questionId = String(item.templateItemId);
+      const templateItem = templateItemsMap.get(questionId) ?? {};
+      const resultado = String(item.resultado || "C").toLowerCase();
+      const response: "c" | "nc" | "na" = resultado === "nc" ? "nc" : resultado === "na" ? "na" : "c";
+      itensMap.set(questionId, {
+        questionId,
+        questionText:
+          templateItem.oQueChecar ??
+          templateItem.criterio ??
+          (typeof item.componente === "string" ? item.componente : null),
+        response,
+        observation: typeof item.observacaoItem === "string" ? item.observacaoItem : null,
+        photoUrls: normalizeStoredImages(item.fotos ?? []),
+        recurrence: false,
+        itemOsNumero: typeof item.osNumeroItem === "string" && item.osNumeroItem.trim()
+          ? item.osNumeroItem.trim().toUpperCase()
+          : null,
+      });
+    });
+
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  const mergedMap = new Map<string, ChecklistAnswer>(itensMap);
+  answers
+    .filter(item => item?.questionId)
+    .forEach(item => {
+      const fallback = mergedMap.get(item.questionId);
+      mergedMap.set(item.questionId, {
+        questionId: item.questionId,
+        questionText:
+          item.questionText ??
+          fallback?.questionText ??
+          templateItemsMap.get(item.questionId)?.oQueChecar ??
+          templateItemsMap.get(item.questionId)?.criterio ??
+          null,
+        response: item.response === "nc" || item.response === "na" ? item.response : fallback?.response ?? "c",
+        observation: item.observation ?? fallback?.observation ?? null,
+        photoUrls: mergeStoredImageCollections(
+          (item as unknown as Record<string, unknown>).photoUrls ??
+            (item as unknown as Record<string, unknown>).photos ??
+            [],
+          fallback?.photoUrls ?? []
+        ),
+        recurrence: item.recurrence ?? fallback?.recurrence ?? false,
+        itemOsNumero: item.itemOsNumero ?? fallback?.itemOsNumero ?? null,
+      });
+    });
+
+  return Array.from(mergedMap.values());
+}

--- a/tests/inspection-answers.test.ts
+++ b/tests/inspection-answers.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { mergeStoredImageCollections, normalizeInspectionAnswers } from "../src/lib/storage/inspection-answers.ts";
+
+test("mergeStoredImageCollections remove duplicadas e preserva ordem", () => {
+  const merged = mergeStoredImageCollections(
+    [
+      { url: "https://r2.dev/a.jpg", provider: "r2" },
+      { url: "https://r2.dev/b.jpg", provider: "r2" },
+    ],
+    [
+      { url: "https://r2.dev/b.jpg", provider: "r2" },
+      { url: "https://imgbb.dev/c.jpg", provider: "imgbb" },
+    ]
+  );
+
+  assert.deepEqual(
+    merged.map(image => image.url),
+    ["https://r2.dev/a.jpg", "https://r2.dev/b.jpg", "https://imgbb.dev/c.jpg"]
+  );
+});
+
+test("normalizeInspectionAnswers combina answers + itens sem perder fotos", () => {
+  const normalized = normalizeInspectionAnswers(
+    {
+      answers: [
+        {
+          questionId: "q1",
+          response: "nc",
+          photoUrls: [{ url: "https://r2.dev/1.jpg", provider: "r2" }],
+        },
+      ],
+      itens: [
+        {
+          templateItemId: "q1",
+          resultado: "NC",
+          fotos: [
+            { url: "https://r2.dev/1.jpg", provider: "r2" },
+            { url: "https://r2.dev/2.jpg", provider: "r2" },
+            { url: "https://r2.dev/3.jpg", provider: "r2" },
+          ],
+        },
+      ],
+    },
+    new Map()
+  );
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0]?.questionId, "q1");
+  assert.deepEqual(
+    normalized[0]?.photoUrls?.map(image => image.url),
+    ["https://r2.dev/1.jpg", "https://r2.dev/2.jpg", "https://r2.dev/3.jpg"]
+  );
+});
+
+test("normalizeInspectionAnswers funciona quando answers está vazio/ausente", () => {
+  const normalized = normalizeInspectionAnswers(
+    {
+      itens: [
+        {
+          templateItemId: "q-legacy",
+          resultado: "NC",
+          observacaoItem: "Foto legacy",
+          fotos: ["https://r2.dev/legacy.jpg"],
+        },
+      ],
+    },
+    new Map([["q-legacy", { oQueChecar: "Checar item legacy" }]])
+  );
+
+  assert.equal(normalized.length, 1);
+  assert.equal(normalized[0]?.questionId, "q-legacy");
+  assert.equal(normalized[0]?.questionText, "Checar item legacy");
+  assert.deepEqual(normalized[0]?.photoUrls?.map(image => image.url), ["https://r2.dev/legacy.jpg"]);
+});


### PR DESCRIPTION
### Motivation

- Support legacy inspection payloads that store per-item data in an `itens` array and ensure photos, observations and OS numbers are correctly merged with modern `answers` payloads.
- Prevent duplicated images across different providers and preserve image order when aggregating photos from multiple sources.
- Improve the NC (non-conformities) admin UX by making the machine filter searchable and robust to labels/tags/IDs.

### Description

- Added `src/lib/storage/inspection-answers.ts` which implements `normalizeInspectionAnswers` and a shared `mergeStoredImageCollections` helper to dedupe and merge image collections while preserving order.
- Updated the inspection edit page (`src/app/admin/inspecoes/[id]/edit/page.tsx`) to read legacy `itens`, derive responses and observations from them, merge photos from both `answers` and `itens`, and include orphan `itens` as form items.
- Updated the non-conformities admin page (`src/app/admin/nc/page.tsx`) to use the image merge helper, change the machine filter from a select to a searchable `Input` with a `datalist`, and adjust filtering logic to match by label/tag/ID.
- Improved the API surface: `src/app/api/inspecoes/[id]/route.ts` now delegates answer normalization to `normalizeInspectionAnswers`, and `src/app/api/inspecoes/[id]/fotos/route.ts` merges photos into both `itens` and `answers`, creates entries if missing, and updates related `issues` inside transactions while deduping photos.
- Added unit tests `tests/inspection-answers.test.ts` covering image merging and normalization behavior.

### Testing

- Ran the new unit tests with `node:test` (`tests/inspection-answers.test.ts`), which include cases for image deduplication/order and merging `answers` with legacy `itens`, and all tests passed.
- Existing automated checks (type checks and runtime tests) were exercised as part of the rollout and did not surface failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c414fca1c88330bc5e5f3bbb9c4ed2)