### PR TITLE
Server-side filtering/pagination + caching for inspections/NC; client react-query and Firestore local cache

### DIFF
--- a/src/app/admin/checklists/page.tsx
+++ b/src/app/admin/checklists/page.tsx
@@ -144,7 +144,7 @@ export default function AdminChecklistsPage() {
   const [error, setError] = useState<string | null>(null);
   const [periodExporting, setPeriodExporting] = useState(false);
   const [periodDeleting, setPeriodDeleting] = useState(false);
-  const [offset, setOffset] = useState(0);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [totalRows, setTotalRows] = useState(0);
   const [hasMore, setHasMore] = useState(false);
   const loadingMoreRef = useRef(false);
@@ -276,7 +276,7 @@ export default function AdminChecklistsPage() {
   }, [machineById, maintainerById, templateById]);
 
 
-  const fetchRows = useCallback(async (reset = true, fetchAll = false, requestOffset = 0) => {
+  const fetchRows = useCallback(async (reset = true, cursor?: string | null) => {
     if (!reset && loadingMoreRef.current) return;
     if (reset) setLoadingRows(true);
     else {
@@ -286,11 +286,9 @@ export default function AdminChecklistsPage() {
     setError(null);
     try {
       const params = new URLSearchParams();
-      if (fetchAll) {
-        params.set("all", "1");
-      } else {
-        params.set("limit", String(CHECKLISTS_PAGE_SIZE));
-        params.set("offset", String(reset ? 0 : requestOffset));
+      params.set("limit", String(CHECKLISTS_PAGE_SIZE));
+      if (!reset && cursor) {
+        params.set("cursor", cursor);
       }
       if (filter.machineTag?.trim()) params.set("machine_query", filter.machineTag.trim());
       if (filter.maintainerId !== "all") params.set("maintainer_id", filter.maintainerId);
@@ -308,17 +306,17 @@ export default function AdminChecklistsPage() {
         items?: Array<{ id: string; data: Record<string, unknown> }>;
         total?: number;
         hasMore?: boolean;
-        nextOffset?: number;
+        nextCursor?: string | null;
       };
       const fetchedRows = mapRows(payload.items ?? []);
       let mergedRows: ChecklistRow[] = [];
       setRows(prev => {
-        mergedRows = reset || fetchAll ? fetchedRows : [...prev, ...fetchedRows];
+        mergedRows = reset ? fetchedRows : [...prev, ...fetchedRows];
         return mergedRows;
       });
       setHasMore(Boolean(payload.hasMore));
-      setTotalRows(typeof payload.total === "number" ? payload.total : mergedRows.length);
-      setOffset(typeof payload.nextOffset === "number" ? payload.nextOffset : mergedRows.length);
+      setTotalRows(mergedRows.length);
+      setNextCursor(typeof payload.nextCursor === "string" ? payload.nextCursor : null);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Erro ao carregar checklists";
       setError(message);
@@ -727,17 +725,9 @@ export default function AdminChecklistsPage() {
               variant="outline"
               disabled={!hasMore || loadingRows || loadingMore}
               loading={loadingMore}
-              onClick={() => fetchRows(false, false, offset)}
+              onClick={() => fetchRows(false, nextCursor)}
             >
               Mostrar mais 30
-            </Button>
-            <Button
-              variant="secondary"
-              disabled={!hasMore || loadingRows || loadingMore}
-              loading={loadingMore}
-              onClick={() => fetchRows(false, true, offset)}
-            >
-              Mostrar todas
             </Button>
           </div>
         </CardContent>

--- a/src/app/admin/checklists/page.tsx
+++ b/src/app/admin/checklists/page.tsx
@@ -3,10 +3,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import {
-  collection,
   deleteDoc,
   doc,
-  getDocs,
 } from "firebase/firestore";
 
 import { Button, buttonStyles } from "@/components/ui/button";
@@ -152,10 +150,7 @@ export default function AdminChecklistsPage() {
   const loadingMoreRef = useRef(false);
   const didInitialFetchRef = useRef(false);
 
-  const machinesCol = useMemo(() => collection(firebaseDb, "machines"), []);
-  const maintainersCol = useMemo(() => collection(firebaseDb, "mantenedores"), []);
-  const templatesCol = useMemo(() => collection(firebaseDb, "templates"), []);
-  const inspectionsCol = useMemo(() => collection(firebaseDb, "inspecoes"), []);
+  const inspectionsCol = useMemo(() => ({ id: "inspecoes" }), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -168,60 +163,52 @@ export default function AdminChecklistsPage() {
           return;
         }
 
-        const [machinesSnap, maintainersSnap, templatesSnap] = await Promise.all([
-          getDocs(machinesCol),
-          getDocs(maintainersCol),
-          getDocs(templatesCol),
+        const [machinesRes, maintainersRes, templatesRes] = await Promise.all([
+          fetch("/api/maquinas", { cache: "force-cache" }),
+          fetch("/api/mantenedores", { cache: "force-cache" }),
+          fetch("/api/templates", { cache: "force-cache" }),
+        ]);
+
+        if (!machinesRes.ok || !maintainersRes.ok || !templatesRes.ok) {
+          throw new Error("Falha ao carregar listas de apoio");
+        }
+
+        const [machinesPayload, maintainersPayload, templatesPayload] = await Promise.all([
+          machinesRes.json(),
+          maintainersRes.json(),
+          templatesRes.json(),
         ]);
 
         if (cancelled) return;
 
-        const machineRecords: MachineOption[] = machinesSnap.docs
-          .map(docSnap => {
-            const data = docSnap.data() ?? {};
-            return {
-              id: docSnap.id,
-              nome: ensureString(data.nome),
-              tag: ensureString(data.tag),
-              setor: ensureString(data.setor),
-              unidade: ensureString(data.unidade),
-            } satisfies MachineOption;
-          })
-          .sort((a, b) => {
-            const labelA = (a.nome ?? a.tag ?? "").toLowerCase();
-            const labelB = (b.nome ?? b.tag ?? "").toLowerCase();
-            return labelA.localeCompare(labelB);
-          });
+        const machineRecords: MachineOption[] = (Array.isArray(machinesPayload) ? machinesPayload : [])
+          .map(item => ({
+            id: String(item.id ?? ""),
+            nome: ensureString(item.nome),
+            tag: ensureString(item.tag),
+            setor: ensureString(item.setor),
+            unidade: ensureString(item.unidade),
+          }))
+          .filter(item => item.id)
+          .sort((a, b) => (a.nome ?? a.tag ?? "").toLowerCase().localeCompare((b.nome ?? b.tag ?? "").toLowerCase()));
 
-        const maintainerRecords: MaintainerOption[] = maintainersSnap.docs
-          .map(docSnap => {
-            const data = docSnap.data() ?? {};
-            return {
-              id: docSnap.id,
-              nome: ensureString(data.nome),
-              matricula: ensureString(data.matricula),
-            } satisfies MaintainerOption;
-          })
-          .sort((a, b) => {
-            const labelA = `${a.matricula ?? ""} ${a.nome ?? ""}`.toLowerCase();
-            const labelB = `${b.matricula ?? ""} ${b.nome ?? ""}`.toLowerCase();
-            return labelA.localeCompare(labelB);
-          });
+        const maintainerRecords: MaintainerOption[] = (Array.isArray(maintainersPayload) ? maintainersPayload : [])
+          .map(item => ({
+            id: String(item.id ?? ""),
+            nome: ensureString(item.nome),
+            matricula: ensureString(item.matricula),
+          }))
+          .filter(item => item.id)
+          .sort((a, b) => `${a.matricula ?? ""} ${a.nome ?? ""}`.toLowerCase().localeCompare(`${b.matricula ?? ""} ${b.nome ?? ""}`.toLowerCase()));
 
-        const templateRecords: TemplateOption[] = templatesSnap.docs
-          .map(docSnap => {
-            const data = docSnap.data() ?? {};
-            return {
-              id: docSnap.id,
-              nome: ensureString(data.nome) ?? ensureString(data.title) ?? null,
-              versao: ensureString(data.versao) ?? ensureString(data.version) ?? null,
-            } satisfies TemplateOption;
-          })
-          .sort((a, b) => {
-            const labelA = (a.nome ?? "").toLowerCase();
-            const labelB = (b.nome ?? "").toLowerCase();
-            return labelA.localeCompare(labelB);
-          });
+        const templateRecords: TemplateOption[] = (Array.isArray(templatesPayload) ? templatesPayload : [])
+          .map(item => ({
+            id: String(item.id ?? ""),
+            nome: ensureString(item.nome) ?? ensureString(item.title) ?? null,
+            versao: ensureString(item.versao) ?? ensureString(item.version) ?? null,
+          }))
+          .filter(item => item.id)
+          .sort((a, b) => (a.nome ?? "").toLowerCase().localeCompare((b.nome ?? "").toLowerCase()));
 
         setMachines(machineRecords);
         setMaintainers(maintainerRecords);
@@ -243,7 +230,7 @@ export default function AdminChecklistsPage() {
     return () => {
       cancelled = true;
     };
-  }, [machinesCol, maintainersCol, templatesCol]);
+  }, []);
 
   const machineById = useMemo(() => new Map(machines.map(machine => [machine.id, machine])), [machines]);
   const maintainerById = useMemo(() => new Map(maintainers.map(item => [item.id, item])), [maintainers]);
@@ -288,53 +275,6 @@ export default function AdminChecklistsPage() {
     });
   }, [machineById, maintainerById, templateById]);
 
-  const applyFilters = useCallback((allRows: ChecklistRow[]) => {
-    const machineQuery = filter.machineTag?.trim().toLowerCase();
-    return allRows.filter(row => {
-      if (machineQuery) {
-        const tag = row.machineTag?.toLowerCase() ?? "";
-        const name = row.machineNome?.toLowerCase() ?? "";
-        const setor = row.machineSetor?.toLowerCase() ?? "";
-        if (!tag.includes(machineQuery) && !name.includes(machineQuery) && !setor.includes(machineQuery)) {
-          return false;
-        }
-      }
-      if (filter.maintainerId !== "all" && row.maintainerId !== filter.maintainerId) {
-        return false;
-      }
-      if (filter.templateId !== "all" && row.templateId !== filter.templateId) {
-        return false;
-      }
-      if (filter.hasNc === "yes" && !row.hasNc) {
-        return false;
-      }
-      if (filter.hasNc === "no" && row.hasNc) {
-        return false;
-      }
-      if (filter.matricula?.trim()) {
-        const wanted = filter.matricula.trim().toLowerCase();
-        const matricula = row.maintainerMatricula?.toLowerCase() ?? "";
-        if (!matricula.includes(wanted)) {
-          return false;
-        }
-      }
-      if (filter.from) {
-        const fromDate = new Date(`${filter.from}T00:00:00`);
-        const createdAt = normalizeDate(row.createdAt);
-        if (!createdAt || createdAt < fromDate) {
-          return false;
-        }
-      }
-      if (filter.to) {
-        const toDate = new Date(`${filter.to}T23:59:59`);
-        const createdAt = normalizeDate(row.createdAt);
-        if (!createdAt || createdAt > toDate) {
-          return false;
-        }
-      }
-      return true;
-    });
-  }, [filter]);
 
   const fetchRows = useCallback(async (reset = true, fetchAll = false, requestOffset = 0) => {
     if (!reset && loadingMoreRef.current) return;
@@ -352,6 +292,14 @@ export default function AdminChecklistsPage() {
         params.set("limit", String(CHECKLISTS_PAGE_SIZE));
         params.set("offset", String(reset ? 0 : requestOffset));
       }
+      if (filter.machineTag?.trim()) params.set("machine_query", filter.machineTag.trim());
+      if (filter.maintainerId !== "all") params.set("maintainer_id", filter.maintainerId);
+      if (filter.templateId !== "all") params.set("template_id", filter.templateId);
+      if (filter.hasNc !== "all") params.set("has_nc", filter.hasNc);
+      if (filter.matricula?.trim()) params.set("matricula", filter.matricula.trim());
+      if (filter.from) params.set("from", filter.from);
+      if (filter.to) params.set("to", filter.to);
+
       const response = await fetch(`/api/admin/checklists?${params.toString()}`, { cache: "no-store" });
       if (!response.ok) {
         throw new Error("Erro ao carregar checklists");
@@ -366,7 +314,7 @@ export default function AdminChecklistsPage() {
       let mergedRows: ChecklistRow[] = [];
       setRows(prev => {
         mergedRows = reset || fetchAll ? fetchedRows : [...prev, ...fetchedRows];
-        return applyFilters(mergedRows);
+        return mergedRows;
       });
       setHasMore(Boolean(payload.hasMore));
       setTotalRows(typeof payload.total === "number" ? payload.total : mergedRows.length);
@@ -381,7 +329,7 @@ export default function AdminChecklistsPage() {
         setLoadingMore(false);
       }
     }
-  }, [applyFilters, mapRows]);
+  }, [filter, mapRows]);
 
   useEffect(() => {
     if (loadingLookups || didInitialFetchRef.current) return;
@@ -447,7 +395,7 @@ export default function AdminChecklistsPage() {
     setPeriodDeleting(true);
     try {
       for (const row of rows) {
-        await deleteDoc(doc(inspectionsCol, row.id));
+        await deleteDoc(doc(firebaseDb, inspectionsCol.id, row.id));
       }
       alert(`Checklists deletados com sucesso (${rows.length}).`);
       await fetchRows();

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -117,7 +117,7 @@ export default function AdminNonConformitiesPage() {
   const [statusFilter, setStatusFilter] = useState("aberta");
   const [maintainerFilter, setMaintainerFilter] = useState("");
   const [maintainers, setMaintainers] = useState<MaintainerOption[]>([]);
-  const [offset, setOffset] = useState(0);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
   const [totalItems, setTotalItems] = useState(0);
   const [savingId, setSavingId] = useState<string | null>(null);
@@ -134,7 +134,7 @@ export default function AdminNonConformitiesPage() {
     setSelectedIds(prev => prev.filter(id => items.some(item => item.id === id)));
   }, [items]);
 
-  const loadData = useCallback(async (reset = true, fetchAll = false, requestOffset = 0) => {
+  const loadData = useCallback(async (reset = true, cursor?: string | null) => {
     if (!reset && loadingMoreRef.current) return;
     if (reset) setLoading(true);
     else {
@@ -151,11 +151,9 @@ export default function AdminNonConformitiesPage() {
       if (machineFilter.trim()) {
         params.set("machine_query", machineFilter.trim());
       }
-      if (fetchAll) {
-        params.set("all", "1");
-      } else {
-        params.set("limit", String(NC_PAGE_SIZE));
-        params.set("offset", String(reset ? 0 : requestOffset));
+      params.set("limit", String(NC_PAGE_SIZE));
+      if (!reset && cursor) {
+        params.set("cursor", cursor);
       }
 
       const session = await fetch(`/api/admin/nc?${params.toString()}`, { cache: "no-store" });
@@ -171,14 +169,14 @@ export default function AdminNonConformitiesPage() {
         treatmentsByResponse?: Record<string, ChecklistNonConformityTreatment[]>;
         total?: number;
         hasMore?: boolean;
-        nextOffset?: number;
+        nextCursor?: string | null;
       };
       const nextItems = sortByLastActivityDesc(payload.items ?? []);
-      setItems(prev => (reset || fetchAll ? nextItems : sortByLastActivityDesc([...prev, ...nextItems])));
+      setItems(prev => (reset ? nextItems : sortByLastActivityDesc([...prev, ...nextItems])));
       setTreatmentsByResponse(payload.treatmentsByResponse ?? {});
       setHasMore(Boolean(payload.hasMore));
-      setTotalItems(typeof payload.total === "number" ? payload.total : nextItems.length);
-      setOffset(typeof payload.nextOffset === "number" ? payload.nextOffset : nextItems.length);
+      setTotalItems(prev => (reset ? nextItems.length : prev + nextItems.length));
+      setNextCursor(typeof payload.nextCursor === "string" ? payload.nextCursor : null);
     } catch (err: unknown) {
       const message = err instanceof Error && err.message ? err.message : "Erro ao carregar dados";
       setError(message);
@@ -825,17 +823,9 @@ export default function AdminNonConformitiesPage() {
               variant="outline"
               disabled={!hasMore || loadingMore || loading}
               loading={loadingMore}
-              onClick={() => loadData(false, false, offset)}
+              onClick={() => loadData(false, nextCursor)}
             >
               Mostrar mais 20
-            </Button>
-            <Button
-              variant="secondary"
-              disabled={!hasMore || loadingMore || loading}
-              loading={loadingMore}
-              onClick={() => loadData(false, true, offset)}
-            >
-              Mostrar todas
             </Button>
           </div>
         </CardContent>

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -148,6 +148,9 @@ export default function AdminNonConformitiesPage() {
       if (maintainerFilter) {
         params.set("mantenedor_id", maintainerFilter);
       }
+      if (machineFilter.trim()) {
+        params.set("machine_query", machineFilter.trim());
+      }
       if (fetchAll) {
         params.set("all", "1");
       } else {
@@ -186,7 +189,7 @@ export default function AdminNonConformitiesPage() {
         setLoadingMore(false);
       }
     }
-  }, [maintainerFilter, statusFilter]);
+  }, [machineFilter, maintainerFilter, statusFilter]);
 
   useEffect(() => {
     let cancelled = false;
@@ -217,7 +220,7 @@ export default function AdminNonConformitiesPage() {
 
   useEffect(() => {
     loadData(true);
-  }, [statusFilter, maintainerFilter, loadData]);
+  }, [statusFilter, maintainerFilter, machineFilter, loadData]);
 
   const machineOptionsForFilter = useMemo(() => {
     return Array.from(new Set(items.map(item => item.machineLabel.trim()).filter(Boolean))).sort((a, b) =>
@@ -225,24 +228,6 @@ export default function AdminNonConformitiesPage() {
     );
   }, [items]);
 
-  const filteredItems = useMemo(() => {
-    const machineSearch = machineFilter.trim().toLowerCase();
-    return items.filter(item => {
-      if (machineSearch) {
-        const machineLabel = item.machineLabel.toLowerCase();
-        const machineTag = (item.machineTag ?? "").toLowerCase();
-        const machineId = (item.machineId ?? "").toLowerCase();
-        if (
-          !machineLabel.includes(machineSearch) &&
-          !machineTag.includes(machineSearch) &&
-          !machineId.includes(machineSearch)
-        ) {
-          return false;
-        }
-      }
-      return true;
-    });
-  }, [items, machineFilter]);
 
   const handleUpdateItem = useCallback((id: string, updates: Partial<NonConformityItem>) => {
     setItems(prev =>
@@ -362,7 +347,7 @@ export default function AdminNonConformitiesPage() {
   }, []);
 
   const handleToggleAllVisible = useCallback(() => {
-    const visibleIds = filteredItems.map(item => item.id);
+    const visibleIds = items.map(item => item.id);
     const allSelected = visibleIds.length > 0 && visibleIds.every(id => selectedIds.includes(id));
 
     setSelectedIds(prev => {
@@ -372,7 +357,7 @@ export default function AdminNonConformitiesPage() {
       const merged = new Set([...prev, ...visibleIds]);
       return Array.from(merged);
     });
-  }, [filteredItems, selectedIds]);
+  }, [items, selectedIds]);
 
   const handleToggleResolution = useCallback((itemId: string) => {
     setExpandedResolutions(prev => {
@@ -421,7 +406,7 @@ export default function AdminNonConformitiesPage() {
   }, [deleteDialogItemId]);
 
   const allVisibleSelected =
-    filteredItems.length > 0 && filteredItems.every(item => selectedIds.includes(item.id));
+    items.length > 0 && items.every(item => selectedIds.includes(item.id));
   const selectedCount = selectedIds.length;
 
   if (loading) {
@@ -530,18 +515,18 @@ export default function AdminNonConformitiesPage() {
         Mostrando {items.length} de {totalItems} não conformidades.
       </div>
 
-      {filteredItems.length > 0 && (
+      {items.length > 0 && (
         <Card>
           <CardContent className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <label className="flex items-center gap-3 text-sm text-[var(--text)]">
               <input
                 type="checkbox"
                 className="h-4 w-4 accent-[var(--primary-500)]"
-                checked={allVisibleSelected && filteredItems.length > 0}
+                checked={allVisibleSelected && items.length > 0}
                 onChange={handleToggleAllVisible}
               />
               <div className="leading-tight">
-                <div>Selecionar todas as {filteredItems.length} NC exibidas</div>
+                <div>Selecionar todas as {items.length} NC exibidas</div>
                 <div className="text-[var(--muted)]">
                   {selectedCount} selecionada{selectedCount === 1 ? "" : "s"}
                 </div>
@@ -577,14 +562,14 @@ export default function AdminNonConformitiesPage() {
         </Card>
       )}
 
-      {filteredItems.length === 0 ? (
+      {items.length === 0 ? (
         <EmptyState
           title="Nenhuma não conformidade encontrada"
           description="Ajuste os filtros ou aguarde novas inspeções com NC registradas."
         />
       ) : (
         <div className="space-y-6">
-          {filteredItems.map(item => {
+          {items.map(item => {
             const itemFeedback = feedback[item.id];
             const hasMaintainerResolution = item.maintainerResolution != null;
             const reincidenciaCount = item.reincidenciaCount;

--- a/src/app/api/admin/checklists/route.ts
+++ b/src/app/api/admin/checklists/route.ts
@@ -1,21 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdminFromRequest } from "@/lib/guards";
 import { adminDb } from "@/lib/firebase-admin";
-import type { ChecklistAnswer } from "@/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+type CursorPayload = {
+  createdAt: string;
+  id: string;
+};
 
 function parsePositiveInt(value: string | null, fallback: number, max: number) {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
   return Math.min(Math.floor(parsed), max);
-}
-
-function parseOffset(value: string | null) {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed < 0) return 0;
-  return Math.floor(parsed);
 }
 
 function toIsoStart(dateInput: string | null) {
@@ -28,70 +26,20 @@ function toIsoEnd(dateInput: string | null) {
   return new Date(`${dateInput}T23:59:59.999Z`).toISOString();
 }
 
-function computeNcCount(data: Record<string, unknown>): number {
-  const qtdNc = data.qtdNC;
-  if (typeof qtdNc === "number" && Number.isFinite(qtdNc)) {
-    return qtdNc;
+function decodeCursor(raw: string | null): CursorPayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    if (typeof parsed?.createdAt !== "string" || typeof parsed?.id !== "string") return null;
+    return { createdAt: parsed.createdAt, id: parsed.id };
+  } catch {
+    return null;
   }
-
-  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
-  if (answers.length > 0) {
-    return answers.filter(answer => answer?.response?.toLowerCase() === "nc").length;
-  }
-
-  const itensRaw = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
-  if (itensRaw.length === 0) return 0;
-  return itensRaw.filter(item => String(item.resultado ?? item.response ?? "c").toLowerCase() === "nc").length;
 }
 
-function matchesChecklistFilters(data: Record<string, unknown>, filters: {
-  machineQuery: string;
-  maintainerId: string;
-  templateId: string;
-  hasNc: "all" | "yes" | "no";
-  matriculaQuery: string;
-}) {
-  const machine = (data.machine ?? {}) as Record<string, unknown>;
-  const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
-  const template = (data.template ?? {}) as Record<string, unknown>;
-
-  const machineId = typeof machine.machineId === "string" ? machine.machineId : typeof machine.id === "string" ? machine.id : "";
-  const machineTag = typeof machine.tag === "string" ? machine.tag : "";
-  const machineNome = typeof machine.nome === "string" ? machine.nome : "";
-  const machineSetor = typeof machine.setor === "string" ? machine.setor : "";
-
-  if (filters.machineQuery) {
-    const haystack = [machineId, machineTag, machineNome, machineSetor].join(" ").toLowerCase();
-    if (!haystack.includes(filters.machineQuery)) return false;
-  }
-
-  if (filters.maintainerId) {
-    const maintainerId =
-      typeof maintainer.maintId === "string"
-        ? maintainer.maintId
-        : typeof maintainer.id === "string"
-          ? maintainer.id
-          : "";
-    if (maintainerId !== filters.maintainerId) return false;
-  }
-
-  if (filters.templateId) {
-    const currentTemplateId = typeof template.id === "string" ? template.id : "";
-    if (currentTemplateId !== filters.templateId) return false;
-  }
-
-  if (filters.matriculaQuery) {
-    const matricula = typeof maintainer.matricula === "string" ? maintainer.matricula.toLowerCase() : "";
-    if (!matricula.includes(filters.matriculaQuery)) return false;
-  }
-
-  if (filters.hasNc !== "all") {
-    const ncCount = computeNcCount(data);
-    if (filters.hasNc === "yes" && ncCount <= 0) return false;
-    if (filters.hasNc === "no" && ncCount > 0) return false;
-  }
-
-  return true;
+function encodeCursor(payload: CursorPayload | null) {
+  if (!payload) return null;
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
 }
 
 export async function GET(req: NextRequest) {
@@ -101,10 +49,7 @@ export async function GET(req: NextRequest) {
   }
 
   const queryParams = req.nextUrl.searchParams;
-  const includeAll = queryParams.get("all") === "1";
-  const limit = parsePositiveInt(queryParams.get("limit"), 30, 200);
-  const offset = parseOffset(queryParams.get("offset"));
-
+  const limit = parsePositiveInt(queryParams.get("limit"), 30, 100);
   const machineQuery = (queryParams.get("machine_query") ?? "").trim().toLowerCase();
   const maintainerId = (queryParams.get("maintainer_id") ?? "").trim();
   const templateId = (queryParams.get("template_id") ?? "").trim();
@@ -112,82 +57,71 @@ export async function GET(req: NextRequest) {
   const matriculaQuery = (queryParams.get("matricula") ?? "").trim().toLowerCase();
   const fromIso = toIsoStart(queryParams.get("from"));
   const toIso = toIsoEnd(queryParams.get("to"));
+  const cursor = decodeCursor(queryParams.get("cursor"));
 
   let queryRef: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = adminDb
-    .collection("inspecoes")
-    .orderBy("createdAt", "desc");
+    .collection("inspecoes_resumo")
+    .orderBy("createdAt", "desc")
+    .orderBy("inspectionId", "desc");
 
-  if (fromIso) {
-    queryRef = queryRef.where("createdAt", ">=", fromIso);
-  }
-  if (toIso) {
-    queryRef = queryRef.where("createdAt", "<=", toIso);
-  }
+  if (fromIso) queryRef = queryRef.where("createdAt", ">=", fromIso);
+  if (toIso) queryRef = queryRef.where("createdAt", "<=", toIso);
+  if (maintainerId) queryRef = queryRef.where("maintainerId", "==", maintainerId);
+  if (templateId) queryRef = queryRef.where("templateId", "==", templateId);
+  if (hasNc === "yes") queryRef = queryRef.where("hasNc", "==", true);
+  if (hasNc === "no") queryRef = queryRef.where("hasNc", "==", false);
+  if (matriculaQuery) queryRef = queryRef.where("maintainerMatriculaLower", "==", matriculaQuery);
 
-  // filtros com igualdade exata são aplicados no backend para reduzir leituras
-  if (maintainerId) {
-    queryRef = queryRef.where("maintainer.maintId", "==", maintainerId);
-  }
-  if (templateId) {
-    queryRef = queryRef.where("template.id", "==", templateId);
+  if (machineQuery) {
+    queryRef = queryRef.where("machineSearchTokens", "array-contains", machineQuery);
   }
 
-  const batchSize = includeAll ? 400 : Math.max(limit * 3, 120);
-  let cursor: FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData> | null = null;
-  let matched = 0;
-  const items: Array<{ id: string; data: FirebaseFirestore.DocumentData }> = [];
-  let hasMore = false;
-
-  while (true) {
-    let pageQuery: FirebaseFirestore.Query<FirebaseFirestore.DocumentData>;
-    if (cursor) {
-      pageQuery = queryRef.startAfter(cursor).limit(batchSize);
-    } else {
-      pageQuery = queryRef.limit(batchSize);
-    }
-    const pageSnap = await pageQuery.get();
-    if (pageSnap.empty) break;
-
-    for (const docSnap of pageSnap.docs) {
-      const data = docSnap.data() ?? {};
-      if (
-        !matchesChecklistFilters(data, {
-          machineQuery,
-          maintainerId,
-          templateId,
-          hasNc,
-          matriculaQuery,
-        })
-      ) {
-        continue;
-      }
-
-      if (!includeAll && matched < offset) {
-        matched += 1;
-        continue;
-      }
-
-      items.push({ id: docSnap.id, data });
-      matched += 1;
-
-      if (!includeAll && items.length >= limit) {
-        hasMore = true;
-        break;
-      }
-    }
-
-    if (hasMore) break;
-    cursor = pageSnap.docs[pageSnap.docs.length - 1] ?? null;
-    if (!cursor || pageSnap.size < batchSize) break;
+  if (cursor) {
+    queryRef = queryRef.startAfter(cursor.createdAt, cursor.id);
   }
 
-  const returnedCount = items.length;
-  const nextOffset = includeAll ? returnedCount : offset + returnedCount;
+  const snap = await queryRef.limit(limit + 1).get();
+  const docs = snap.docs.slice(0, limit);
+  const hasMore = snap.docs.length > limit;
+  const nextCursor = hasMore
+    ? encodeCursor({
+        createdAt: String(docs[docs.length - 1]?.data()?.createdAt ?? ""),
+        id: String(docs[docs.length - 1]?.data()?.inspectionId ?? docs[docs.length - 1]?.id ?? ""),
+      })
+    : null;
+
+  const items = docs.map(docSnap => {
+    const data = docSnap.data() ?? {};
+    return {
+      id: String(data.inspectionId ?? docSnap.id),
+      data: {
+        createdAt: data.createdAt ?? null,
+        machine: {
+          machineId: data.machineId ?? null,
+          nome: data.machineNome ?? null,
+          tag: data.machineTag ?? null,
+          setor: data.machineSetor ?? null,
+        },
+        maintainer: {
+          maintId: data.maintainerId ?? null,
+          nome: data.maintainerNome ?? null,
+          matricula: data.maintainerMatricula ?? null,
+        },
+        template: {
+          id: data.templateId ?? null,
+          nome: data.templateNome ?? null,
+          versao: data.templateVersao ?? null,
+        },
+        osNumero: data.osNumero ?? null,
+        qtdNC: typeof data.qtdNc === "number" ? data.qtdNc : 0,
+        hasNc: Boolean(data.hasNc),
+      },
+    };
+  });
 
   return NextResponse.json({
     items,
-    total: includeAll ? returnedCount : offset + returnedCount + (hasMore ? 1 : 0),
     hasMore,
-    nextOffset,
+    nextCursor,
   });
 }

--- a/src/app/api/admin/checklists/route.ts
+++ b/src/app/api/admin/checklists/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdminFromRequest } from "@/lib/guards";
 import { adminDb } from "@/lib/firebase-admin";
+import type { ChecklistAnswer } from "@/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -17,6 +18,82 @@ function parseOffset(value: string | null) {
   return Math.floor(parsed);
 }
 
+function toIsoStart(dateInput: string | null) {
+  if (!dateInput || !/^\d{4}-\d{2}-\d{2}$/.test(dateInput)) return null;
+  return new Date(`${dateInput}T00:00:00.000Z`).toISOString();
+}
+
+function toIsoEnd(dateInput: string | null) {
+  if (!dateInput || !/^\d{4}-\d{2}-\d{2}$/.test(dateInput)) return null;
+  return new Date(`${dateInput}T23:59:59.999Z`).toISOString();
+}
+
+function computeNcCount(data: Record<string, unknown>): number {
+  const qtdNc = data.qtdNC;
+  if (typeof qtdNc === "number" && Number.isFinite(qtdNc)) {
+    return qtdNc;
+  }
+
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length > 0) {
+    return answers.filter(answer => answer?.response?.toLowerCase() === "nc").length;
+  }
+
+  const itensRaw = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  if (itensRaw.length === 0) return 0;
+  return itensRaw.filter(item => String(item.resultado ?? item.response ?? "c").toLowerCase() === "nc").length;
+}
+
+function matchesChecklistFilters(data: Record<string, unknown>, filters: {
+  machineQuery: string;
+  maintainerId: string;
+  templateId: string;
+  hasNc: "all" | "yes" | "no";
+  matriculaQuery: string;
+}) {
+  const machine = (data.machine ?? {}) as Record<string, unknown>;
+  const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
+  const template = (data.template ?? {}) as Record<string, unknown>;
+
+  const machineId = typeof machine.machineId === "string" ? machine.machineId : typeof machine.id === "string" ? machine.id : "";
+  const machineTag = typeof machine.tag === "string" ? machine.tag : "";
+  const machineNome = typeof machine.nome === "string" ? machine.nome : "";
+  const machineSetor = typeof machine.setor === "string" ? machine.setor : "";
+
+  if (filters.machineQuery) {
+    const haystack = [machineId, machineTag, machineNome, machineSetor].join(" ").toLowerCase();
+    if (!haystack.includes(filters.machineQuery)) return false;
+  }
+
+  if (filters.maintainerId) {
+    const maintainerId =
+      typeof maintainer.maintId === "string"
+        ? maintainer.maintId
+        : typeof maintainer.id === "string"
+          ? maintainer.id
+          : "";
+    if (maintainerId !== filters.maintainerId) return false;
+  }
+
+  if (filters.templateId) {
+    const currentTemplateId = typeof template.id === "string" ? template.id : "";
+    if (currentTemplateId !== filters.templateId) return false;
+  }
+
+  if (filters.matriculaQuery) {
+    const matricula = typeof maintainer.matricula === "string" ? maintainer.matricula.toLowerCase() : "";
+    if (!matricula.includes(filters.matriculaQuery)) return false;
+  }
+
+  if (filters.hasNc !== "all") {
+    const ncCount = computeNcCount(data);
+    if (filters.hasNc === "yes" && ncCount <= 0) return false;
+    if (filters.hasNc === "no" && ncCount > 0) return false;
+  }
+
+  return true;
+}
+
 export async function GET(req: NextRequest) {
   const isAdmin = await requireAdminFromRequest(req);
   if (!isAdmin) {
@@ -25,26 +102,92 @@ export async function GET(req: NextRequest) {
 
   const queryParams = req.nextUrl.searchParams;
   const includeAll = queryParams.get("all") === "1";
-  const limit = parsePositiveInt(queryParams.get("limit"), 30, 1000);
+  const limit = parsePositiveInt(queryParams.get("limit"), 30, 200);
   const offset = parseOffset(queryParams.get("offset"));
 
-  const baseQuery = adminDb.collection("inspecoes").orderBy("createdAt", "desc");
-  const [countSnap, docsSnap] = await Promise.all([
-    adminDb.collection("inspecoes").count().get(),
-    includeAll ? baseQuery.get() : baseQuery.offset(offset).limit(limit).get(),
-  ]);
+  const machineQuery = (queryParams.get("machine_query") ?? "").trim().toLowerCase();
+  const maintainerId = (queryParams.get("maintainer_id") ?? "").trim();
+  const templateId = (queryParams.get("template_id") ?? "").trim();
+  const hasNc = (queryParams.get("has_nc") ?? "all") as "all" | "yes" | "no";
+  const matriculaQuery = (queryParams.get("matricula") ?? "").trim().toLowerCase();
+  const fromIso = toIsoStart(queryParams.get("from"));
+  const toIso = toIsoEnd(queryParams.get("to"));
 
-  const total = countSnap.data().count;
-  const returnedCount = includeAll ? total : docsSnap.docs.length;
-  const nextOffset = includeAll ? total : offset + returnedCount;
+  let queryRef: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = adminDb
+    .collection("inspecoes")
+    .orderBy("createdAt", "desc");
+
+  if (fromIso) {
+    queryRef = queryRef.where("createdAt", ">=", fromIso);
+  }
+  if (toIso) {
+    queryRef = queryRef.where("createdAt", "<=", toIso);
+  }
+
+  // filtros com igualdade exata são aplicados no backend para reduzir leituras
+  if (maintainerId) {
+    queryRef = queryRef.where("maintainer.maintId", "==", maintainerId);
+  }
+  if (templateId) {
+    queryRef = queryRef.where("template.id", "==", templateId);
+  }
+
+  const batchSize = includeAll ? 400 : Math.max(limit * 3, 120);
+  let cursor: FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData> | null = null;
+  let matched = 0;
+  const items: Array<{ id: string; data: FirebaseFirestore.DocumentData }> = [];
+  let hasMore = false;
+
+  while (true) {
+    let pageQuery: FirebaseFirestore.Query<FirebaseFirestore.DocumentData>;
+    if (cursor) {
+      pageQuery = queryRef.startAfter(cursor).limit(batchSize);
+    } else {
+      pageQuery = queryRef.limit(batchSize);
+    }
+    const pageSnap = await pageQuery.get();
+    if (pageSnap.empty) break;
+
+    for (const docSnap of pageSnap.docs) {
+      const data = docSnap.data() ?? {};
+      if (
+        !matchesChecklistFilters(data, {
+          machineQuery,
+          maintainerId,
+          templateId,
+          hasNc,
+          matriculaQuery,
+        })
+      ) {
+        continue;
+      }
+
+      if (!includeAll && matched < offset) {
+        matched += 1;
+        continue;
+      }
+
+      items.push({ id: docSnap.id, data });
+      matched += 1;
+
+      if (!includeAll && items.length >= limit) {
+        hasMore = true;
+        break;
+      }
+    }
+
+    if (hasMore) break;
+    cursor = pageSnap.docs[pageSnap.docs.length - 1] ?? null;
+    if (!cursor || pageSnap.size < batchSize) break;
+  }
+
+  const returnedCount = items.length;
+  const nextOffset = includeAll ? returnedCount : offset + returnedCount;
 
   return NextResponse.json({
-    items: docsSnap.docs.map(docSnap => ({
-      id: docSnap.id,
-      data: docSnap.data(),
-    })),
-    total,
-    hasMore: nextOffset < total,
+    items,
+    total: includeAll ? returnedCount : offset + returnedCount + (hasMore ? 1 : 0),
+    hasMore,
     nextOffset,
   });
 }

--- a/src/app/api/admin/nc/route.ts
+++ b/src/app/api/admin/nc/route.ts
@@ -230,6 +230,29 @@ function resolveMachineIdFromInspection(data: Record<string, unknown>): string |
   return null;
 }
 
+async function getDocumentsByIds(
+  collectionName: string,
+  ids: string[]
+): Promise<FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>[]> {
+  if (ids.length === 0) return [];
+  const uniqueIds = Array.from(new Set(ids.filter(Boolean)));
+  const chunkSize = 300;
+  const snapshots: FirebaseFirestore.DocumentSnapshot<FirebaseFirestore.DocumentData>[] = [];
+  for (let i = 0; i < uniqueIds.length; i += chunkSize) {
+    const refs = uniqueIds.slice(i, i + chunkSize).map(id => adminDb.collection(collectionName).doc(id));
+    const chunkSnapshots = await adminDb.getAll(...refs);
+    snapshots.push(...chunkSnapshots);
+  }
+  return snapshots;
+}
+
+function matchesMachineQuery(item: NonConformityItemResponse, machineQuery: string) {
+  if (!machineQuery) return true;
+  const query = machineQuery.toLowerCase();
+  const haystack = [item.machineLabel, item.machineTag ?? "", item.machineId ?? ""].join(" ").toLowerCase();
+  return haystack.includes(query);
+}
+
 export async function GET(req: NextRequest) {
   const isAdmin = await requireAdminFromRequest(req);
   if (!isAdmin) {
@@ -242,34 +265,106 @@ export async function GET(req: NextRequest) {
   const includeAll = queryParams.get("all") === "1";
   const issueStatusFilter = (queryParams.get("status") ?? "aberta").trim().toLowerCase();
   const maintainerIdFilter = queryParams.get("mantenedor_id")?.trim() ?? "";
+  const machineQueryFilter = (queryParams.get("machine_query") ?? "").trim();
 
   const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.floor(rawLimit), 500) : 20;
   const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? Math.floor(rawOffset) : 0;
   const allowedStatuses = new Set(["aberta", "concluida", "resolvida"]);
   const normalizedIssueStatus = allowedStatuses.has(issueStatusFilter) ? issueStatusFilter : "aberta";
 
-  const issuesQuery = adminDb.collection("issues").where("status", "==", normalizedIssueStatus);
+  let issuesSnap: FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>;
 
-  const [machinesSnap, templatesSnap, issuesSnap, inspectionsSnap] = await Promise.all([
-    adminDb.collection("machines").get(),
-    adminDb.collection("templates").get(),
-    issuesQuery.get(),
-    adminDb.collection("inspecoes").get(),
-  ]);
+  if (machineQueryFilter) {
+    const machinesSnap = await adminDb.collection("machines").get();
+    const normalizedMachineQuery = machineQueryFilter.toLowerCase();
+    const candidateMachineIds = machinesSnap.docs
+      .filter(docSnap => {
+        const data = docSnap.data() ?? {};
+        const haystack = [docSnap.id, data.tag ?? "", data.nome ?? ""].join(" ").toLowerCase();
+        return haystack.includes(normalizedMachineQuery);
+      })
+      .map(docSnap => docSnap.id);
 
-  const machineOptions: MachineOption[] = machinesSnap.docs.map(docSnap => {
-    const data = docSnap.data() ?? {};
-    return {
-      id: docSnap.id,
-      nome: typeof data.nome === "string" ? data.nome : docSnap.id,
-      tag: data.tag ? String(data.tag) : null,
-      templateId: typeof data.templateId === "string" ? data.templateId : null,
-    } satisfies MachineOption;
-  });
+    if (candidateMachineIds.length > 0) {
+      const chunks: string[][] = [];
+      for (let index = 0; index < candidateMachineIds.length; index += 10) {
+        chunks.push(candidateMachineIds.slice(index, index + 10));
+      }
+      const chunkSnapshots = await Promise.all(
+        chunks.map(chunk =>
+          adminDb.collection("issues").where("status", "==", normalizedIssueStatus).where("machineId", "in", chunk).get()
+        )
+      );
+      const issuesMap = new Map<string, FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>>();
+      chunkSnapshots.forEach(snap => {
+        snap.forEach(docSnap => issuesMap.set(docSnap.id, docSnap));
+      });
+      issuesSnap = {
+        docs: Array.from(issuesMap.values()),
+      } as unknown as FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>;
+    } else {
+      issuesSnap = await adminDb.collection("issues").where("status", "==", normalizedIssueStatus).get();
+    }
+  } else {
+    issuesSnap = await adminDb.collection("issues").where("status", "==", normalizedIssueStatus).get();
+  }
+
+  const responseIds = issuesSnap.docs
+    .map(issueDoc => {
+      const data = issueDoc.data() ?? {};
+      return typeof data.abertaEmInspecaoId === "string" ? data.abertaEmInspecaoId : null;
+    })
+    .filter((value): value is string => Boolean(value));
+
+  const inspectionsDocs = await getDocumentsByIds("inspecoes", responseIds);
+
+  const machineIdsFromIssues = issuesSnap.docs
+    .map(issueDoc => {
+      const data = issueDoc.data() ?? {};
+      return typeof data.machineId === "string" ? data.machineId : null;
+    })
+    .filter((value): value is string => Boolean(value));
+
+  const machineIdsFromInspections = inspectionsDocs
+    .map(inspectionDoc => resolveMachineIdFromInspection(inspectionDoc.data() ?? {}))
+    .filter((value): value is string => Boolean(value));
+
+  const machineDocs = await getDocumentsByIds("machines", [...machineIdsFromIssues, ...machineIdsFromInspections]);
+
+  const machineOptions: MachineOption[] = machineDocs
+    .filter(docSnap => docSnap.exists)
+    .map(docSnap => {
+      const data = docSnap.data() ?? {};
+      return {
+        id: docSnap.id,
+        nome: typeof data.nome === "string" ? data.nome : docSnap.id,
+        tag: data.tag ? String(data.tag) : null,
+        templateId: typeof data.templateId === "string" ? data.templateId : null,
+      } satisfies MachineOption;
+    });
+
   const machinesById = new Map(machineOptions.map(machine => [machine.id, machine]));
 
+  const templateIds = new Set<string>();
+  inspectionsDocs.forEach(inspectionDoc => {
+    const inspectionData = inspectionDoc.data() ?? {};
+    const templateInfo = (inspectionData.template ?? {}) as Record<string, unknown>;
+    const machine = (inspectionData.machine ?? {}) as Record<string, unknown>;
+    const machineId = resolveMachineIdFromInspection(inspectionData);
+    const machineOption = machineId ? machinesById.get(machineId) : undefined;
+    const templateId =
+      typeof templateInfo.id === "string"
+        ? templateInfo.id
+        : typeof machine.templateId === "string"
+          ? machine.templateId
+          : machineOption?.templateId ?? null;
+    if (templateId) templateIds.add(templateId);
+  });
+
+  const templateDocs = await getDocumentsByIds("templates", Array.from(templateIds));
   const templateMap = new Map<string, TemplateMeta>();
-  templatesSnap.docs.forEach(docSnap => {
+  templateDocs.forEach(docSnap => {
+    if (!docSnap.exists) return;
     const data = docSnap.data() ?? {};
     const itens = Array.isArray(data.itens) ? (data.itens as TemplateItemData[]) : [];
     const itensMap = new Map<string, TemplateItemData>();
@@ -287,7 +382,8 @@ export async function GET(req: NextRequest) {
   const treatmentsByResponse: Record<string, ChecklistNonConformityTreatment[]> = {};
   const ncHistoryByLogicalId = new Map<string, NonConformityRecurrenceHistoryItem[]>();
 
-  inspectionsSnap.docs.forEach(inspectionDoc => {
+  inspectionsDocs.forEach(inspectionDoc => {
+    if (!inspectionDoc.exists) return;
     const inspectionData = inspectionDoc.data() ?? {};
     const machine = (inspectionData.machine ?? {}) as Record<string, unknown>;
     const maintainer = (inspectionData.maintainer ?? {}) as Record<string, unknown>;
@@ -362,6 +458,7 @@ export async function GET(req: NextRequest) {
 
   const builtItems: NonConformityItemResponse[] = [];
   const issuesToMigrate: Array<{ id: string; lastReincidenciaAt: string }> = [];
+
   issuesSnap.docs.forEach(issueDoc => {
     const issueData = issueDoc.data() ?? {};
     const machineId = typeof issueData.machineId === "string" ? issueData.machineId : null;
@@ -474,21 +571,28 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  const sortedItems = sortByLastActivityDesc(
-    maintainerIdFilter
-      ? builtItems.filter(item => item.maintainerId === maintainerIdFilter)
-      : builtItems
+  const filtered = sortByLastActivityDesc(
+    builtItems
+      .filter(item => (maintainerIdFilter ? item.maintainerId === maintainerIdFilter : true))
+      .filter(item => matchesMachineQuery(item, machineQueryFilter))
   );
-  const total = sortedItems.length;
-  const paginatedItems = includeAll ? sortedItems : sortedItems.slice(offset, offset + limit);
+
+  const total = filtered.length;
+  const paginatedItems = includeAll ? filtered : filtered.slice(offset, offset + limit);
   const returnedCount = includeAll ? total : Math.min(limit, Math.max(total - offset, 0));
   const nextOffset = includeAll ? total : offset + returnedCount;
+
+  const pagedTreatmentsByResponse: Record<string, ChecklistNonConformityTreatment[]> = {};
+  paginatedItems.forEach(item => {
+    if (!item.responseId) return;
+    pagedTreatmentsByResponse[item.responseId] = treatmentsByResponse[item.responseId] ?? [];
+  });
 
   return NextResponse.json({
     items: paginatedItems,
     total,
     hasMore: nextOffset < total,
     nextOffset,
-    treatmentsByResponse,
+    treatmentsByResponse: pagedTreatmentsByResponse,
   });
 }

--- a/src/app/api/admin/nc/route.ts
+++ b/src/app/api/admin/nc/route.ts
@@ -246,11 +246,25 @@ async function getDocumentsByIds(
   return snapshots;
 }
 
-function matchesMachineQuery(item: NonConformityItemResponse, machineQuery: string) {
-  if (!machineQuery) return true;
-  const query = machineQuery.toLowerCase();
-  const haystack = [item.machineLabel, item.machineTag ?? "", item.machineId ?? ""].join(" ").toLowerCase();
-  return haystack.includes(query);
+type CursorPayload = {
+  createdAt: string;
+  id: string;
+};
+
+function decodeCursor(raw: string | null): CursorPayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(Buffer.from(raw, "base64url").toString("utf8"));
+    if (typeof parsed?.createdAt !== "string" || typeof parsed?.id !== "string") return null;
+    return { createdAt: parsed.createdAt, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(payload: CursorPayload | null) {
+  if (!payload) return null;
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
 }
 
 export async function GET(req: NextRequest) {
@@ -261,53 +275,48 @@ export async function GET(req: NextRequest) {
 
   const queryParams = req.nextUrl.searchParams;
   const rawLimit = Number(queryParams.get("limit") ?? "20");
-  const rawOffset = Number(queryParams.get("offset") ?? "0");
   const includeAll = queryParams.get("all") === "1";
   const issueStatusFilter = (queryParams.get("status") ?? "aberta").trim().toLowerCase();
   const maintainerIdFilter = queryParams.get("mantenedor_id")?.trim() ?? "";
-  const machineQueryFilter = (queryParams.get("machine_query") ?? "").trim();
+  const machineQueryFilter = (queryParams.get("machine_query") ?? "").trim().toLowerCase();
+  const cursor = decodeCursor(queryParams.get("cursor"));
 
-  const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.floor(rawLimit), 500) : 20;
-  const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? Math.floor(rawOffset) : 0;
+  const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(Math.floor(rawLimit), 200) : 20;
   const allowedStatuses = new Set(["aberta", "concluida", "resolvida"]);
   const normalizedIssueStatus = allowedStatuses.has(issueStatusFilter) ? issueStatusFilter : "aberta";
 
-  let issuesSnap: FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>;
+  let issuesQuery: FirebaseFirestore.Query<FirebaseFirestore.DocumentData> = adminDb
+    .collection("issues")
+    .where("status", "==", normalizedIssueStatus);
+
+  if (maintainerIdFilter) {
+    issuesQuery = issuesQuery.where("maintainerId", "==", maintainerIdFilter);
+  }
 
   if (machineQueryFilter) {
-    const machinesSnap = await adminDb.collection("machines").get();
-    const normalizedMachineQuery = machineQueryFilter.toLowerCase();
-    const candidateMachineIds = machinesSnap.docs
-      .filter(docSnap => {
-        const data = docSnap.data() ?? {};
-        const haystack = [docSnap.id, data.tag ?? "", data.nome ?? ""].join(" ").toLowerCase();
-        return haystack.includes(normalizedMachineQuery);
-      })
-      .map(docSnap => docSnap.id);
-
-    if (candidateMachineIds.length > 0) {
-      const chunks: string[][] = [];
-      for (let index = 0; index < candidateMachineIds.length; index += 10) {
-        chunks.push(candidateMachineIds.slice(index, index + 10));
-      }
-      const chunkSnapshots = await Promise.all(
-        chunks.map(chunk =>
-          adminDb.collection("issues").where("status", "==", normalizedIssueStatus).where("machineId", "in", chunk).get()
-        )
-      );
-      const issuesMap = new Map<string, FirebaseFirestore.QueryDocumentSnapshot<FirebaseFirestore.DocumentData>>();
-      chunkSnapshots.forEach(snap => {
-        snap.forEach(docSnap => issuesMap.set(docSnap.id, docSnap));
-      });
-      issuesSnap = {
-        docs: Array.from(issuesMap.values()),
-      } as unknown as FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>;
+    if (/^[a-z0-9_-]+$/i.test(machineQueryFilter)) {
+      issuesQuery = issuesQuery.where("machineTagLower", "==", machineQueryFilter);
     } else {
-      issuesSnap = await adminDb.collection("issues").where("status", "==", normalizedIssueStatus).get();
+      return NextResponse.json({ items: [], hasMore: false, nextCursor: null, treatmentsByResponse: {} });
     }
-  } else {
-    issuesSnap = await adminDb.collection("issues").where("status", "==", normalizedIssueStatus).get();
   }
+
+  issuesQuery = issuesQuery.orderBy("createdAt", "desc").orderBy("__name__", "desc");
+
+  if (cursor) {
+    issuesQuery = issuesQuery.startAfter(cursor.createdAt, cursor.id);
+  }
+
+  const issuesSnapRaw = await issuesQuery.limit((includeAll ? 500 : limit) + 1).get();
+  const hasMore = !includeAll && issuesSnapRaw.docs.length > limit;
+  const pageIssues = includeAll ? issuesSnapRaw.docs : issuesSnapRaw.docs.slice(0, limit);
+  const issuesSnap = { docs: pageIssues } as FirebaseFirestore.QuerySnapshot<FirebaseFirestore.DocumentData>;
+  const nextCursor = hasMore
+    ? encodeCursor({
+        createdAt: String(pageIssues[pageIssues.length - 1]?.data()?.createdAt ?? ""),
+        id: String(pageIssues[pageIssues.length - 1]?.id ?? ""),
+      })
+    : null;
 
   const responseIds = issuesSnap.docs
     .map(issueDoc => {
@@ -571,28 +580,18 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  const filtered = sortByLastActivityDesc(
-    builtItems
-      .filter(item => (maintainerIdFilter ? item.maintainerId === maintainerIdFilter : true))
-      .filter(item => matchesMachineQuery(item, machineQueryFilter))
-  );
-
-  const total = filtered.length;
-  const paginatedItems = includeAll ? filtered : filtered.slice(offset, offset + limit);
-  const returnedCount = includeAll ? total : Math.min(limit, Math.max(total - offset, 0));
-  const nextOffset = includeAll ? total : offset + returnedCount;
+  const sortedItems = sortByLastActivityDesc(builtItems);
 
   const pagedTreatmentsByResponse: Record<string, ChecklistNonConformityTreatment[]> = {};
-  paginatedItems.forEach(item => {
+  sortedItems.forEach(item => {
     if (!item.responseId) return;
     pagedTreatmentsByResponse[item.responseId] = treatmentsByResponse[item.responseId] ?? [];
   });
 
   return NextResponse.json({
-    items: paginatedItems,
-    total,
-    hasMore: nextOffset < total,
-    nextOffset,
+    items: sortedItems,
+    hasMore,
+    nextCursor,
     treatmentsByResponse: pagedTreatmentsByResponse,
   });
 }

--- a/src/app/api/inspecoes/route.ts
+++ b/src/app/api/inspecoes/route.ts
@@ -11,6 +11,7 @@ import { isMaintainerProfileId } from "@/lib/signature-profiles";
 import { fromDataUrl } from "@/lib/storage/dataUrl";
 import { r2Provider } from "@/lib/storage/r2Provider";
 import { buildIssueRecurrenceUpdates } from "@/lib/non-conformity-priority";
+import { upsertInspectionSummary } from "@/lib/inspection-summary";
 import type { StoredImage } from "@/types";
 
 export const runtime = "nodejs";
@@ -377,6 +378,9 @@ export async function POST(req: NextRequest) {
       await issueRef.set({
         machineId: machineRecord.id,
         tag: machineRecord.tag ?? null,
+        machineTagLower: machineRecord.tag ? String(machineRecord.tag).toLowerCase() : null,
+        maintainerId: auth.store.id ?? null,
+        maintainerMatricula: auth.store.matricula ?? null,
         templateItemId: item.templateItemId,
         descricao,
         osNumero: item.osNumeroItem ?? null,
@@ -507,6 +511,7 @@ export async function POST(req: NextRequest) {
       answers: answersPayload,
       nonConformityTreatments: treatmentsPayload,
       qtdNC,
+      hasNc: qtdNC > 0,
       createdAt: nowIso,
       createdAtTimestamp: nowTimestamp,
       iniciadaEm: nowIso,
@@ -515,6 +520,29 @@ export async function POST(req: NextRequest) {
       finalizadaEmTimestamp: nowTimestamp,
       issuesCriadas,
       issuesResolvidas,
+    });
+
+    await upsertInspectionSummary({
+      id: inspectionId,
+      createdAt: nowIso,
+      machine: {
+        machineId: machineRecord.id,
+        tag: machineRecord.tag ?? null,
+        nome: machineRecord.nome ?? null,
+        setor: machineRecord.setor ?? null,
+      },
+      maintainer: {
+        maintId: auth.store.id ?? null,
+        nome: auth.store.nome ?? null,
+        matricula: auth.store.matricula ?? null,
+      },
+      template: {
+        id: templateSnap.id,
+        nome: typeof templateData.nome === "string" ? templateData.nome : null,
+        versao: typeof templateData.versao === "string" ? templateData.versao : null,
+      },
+      osNumero: osNumero ?? null,
+      qtdNc: qtdNC,
     });
 
     if (programacaoDoc) {

--- a/src/app/api/me/inspecoes/route.ts
+++ b/src/app/api/me/inspecoes/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { adminDb } from "@/lib/firebase-admin";
 import { requireMaint } from "@/lib/guards";
+import { getOrSetServerCache } from "@/lib/server-memory-cache";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
 type MaintInspectionSummary = {
   id: string;
@@ -88,36 +89,52 @@ export async function GET(req: NextRequest) {
     const limitValue = clampLimit(Number(params.get("limit")), params.has("date") ? 15 : 25, 100);
     const cursorId = params.get("cursor");
     const range = deriveRange(params);
+    const maintId = auth.store.id!;
 
-    let queryRef = adminDb
-      .collection("inspecoes")
-      .where("maintainer.maintId", "==", auth.store.id!)
-      .orderBy("finalizadaEm", "desc");
+    const cacheKey = [
+      "me:inspecoes",
+      maintId,
+      String(limitValue),
+      cursorId ?? "",
+      range.start ?? "",
+      range.end ?? "",
+    ].join(":");
 
-    if (range.start) {
-      queryRef = queryRef.where("finalizadaEm", ">=", range.start);
-    }
-    if (range.end) {
-      queryRef = queryRef.where("finalizadaEm", "<=", range.end);
-    }
+    const payload = await getOrSetServerCache(cacheKey, 30_000, async () => {
+      let queryRef = adminDb
+        .collection("inspecoes")
+        .where("maintainer.maintId", "==", maintId)
+        .orderBy("finalizadaEm", "desc");
 
-    if (cursorId) {
-      const cursorSnap = await adminDb.collection("inspecoes").doc(cursorId).get();
-      if (cursorSnap.exists) {
-        queryRef = queryRef.startAfter(cursorSnap);
+      if (range.start) {
+        queryRef = queryRef.where("finalizadaEm", ">=", range.start);
       }
-    }
+      if (range.end) {
+        queryRef = queryRef.where("finalizadaEm", "<=", range.end);
+      }
 
-    const snapshot = await queryRef.limit(limitValue).get();
-    const items = snapshot.docs.map(mapInspectionSummary);
+      if (cursorId) {
+        const cursorSnap = await adminDb.collection("inspecoes").doc(cursorId).get();
+        if (cursorSnap.exists) {
+          queryRef = queryRef.startAfter(cursorSnap);
+        }
+      }
 
-    const hasMore = snapshot.size === limitValue;
-    const nextCursor = hasMore ? snapshot.docs[snapshot.docs.length - 1]?.id ?? null : null;
+      const snapshot = await queryRef.limit(limitValue).get();
+      const items = snapshot.docs.map(mapInspectionSummary);
+      const hasMore = snapshot.size === limitValue;
+      const nextCursor = hasMore ? snapshot.docs[snapshot.docs.length - 1]?.id ?? null : null;
 
-    return NextResponse.json({ items, nextCursor });
+      return { items, nextCursor };
+    });
+
+    return NextResponse.json(payload, {
+      headers: {
+        "Cache-Control": "private, max-age=30, stale-while-revalidate=60",
+      },
+    });
   } catch (error) {
     const message = error instanceof Error && error.message ? error.message : "INTERNAL_ERROR";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }
-

--- a/src/app/api/me/machines/route.ts
+++ b/src/app/api/me/machines/route.ts
@@ -2,9 +2,10 @@ import { NextResponse } from "next/server";
 import { adminDb } from "@/lib/firebase-admin";
 import { requireMaint } from "@/lib/guards";
 import { getMachinesByIdsChunked } from "@/lib/db/machines";
+import { getOrSetServerCache } from "@/lib/server-memory-cache";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
 export async function GET() {
   const auth = await requireMaint();
@@ -13,43 +14,54 @@ export async function GET() {
   }
 
   try {
-    const maintDoc = await adminDb.collection("mantenedores").doc(auth.store.id!).get();
-    if (!maintDoc.exists) {
-      return NextResponse.json({ error: "MAINTAINER_NOT_FOUND" }, { status: 403 });
-    }
+    const maintId = auth.store.id!;
+    const cacheKey = `me:machines:${maintId}`;
+    const results = await getOrSetServerCache(cacheKey, 60_000, async () => {
+      const maintDoc = await adminDb.collection("mantenedores").doc(maintId).get();
+      if (!maintDoc.exists) {
+        throw new Error("MAINTAINER_NOT_FOUND");
+      }
 
-    const maintData = maintDoc.data() ?? {};
-    const machinesIds = Array.isArray(maintData.machines)
-      ? (maintData.machines as string[]).filter(Boolean)
-      : [];
+      const maintData = maintDoc.data() ?? {};
+      const machinesIds = Array.isArray(maintData.machines)
+        ? (maintData.machines as string[]).filter(Boolean)
+        : [];
 
-    if (machinesIds.length === 0) {
-      return NextResponse.json([]);
-    }
+      if (machinesIds.length === 0) {
+        return [];
+      }
 
-    const docs = await getMachinesByIdsChunked(machinesIds);
+      const docs = await getMachinesByIdsChunked(machinesIds);
 
-    const results = docs
-      .filter(doc => doc.ativo !== false)
-      .map(doc => ({
-        id: doc.id,
-        tag: typeof doc.tag === "string" ? doc.tag : null,
-        nome: typeof doc.nome === "string" ? doc.nome : null,
-        setor: typeof doc.setor === "string" ? doc.setor : null,
-        unidade: typeof doc.unidade === "string" ? doc.unidade : null,
-        fotoUrl: typeof doc.fotoUrl === "string" ? doc.fotoUrl : null,
-      }));
+      const mapped = docs
+        .filter(doc => doc.ativo !== false)
+        .map(doc => ({
+          id: doc.id,
+          tag: typeof doc.tag === "string" ? doc.tag : null,
+          nome: typeof doc.nome === "string" ? doc.nome : null,
+          setor: typeof doc.setor === "string" ? doc.setor : null,
+          unidade: typeof doc.unidade === "string" ? doc.unidade : null,
+          fotoUrl: typeof doc.fotoUrl === "string" ? doc.fotoUrl : null,
+        }));
 
-    results.sort((a, b) => {
-      const nameA = (a.nome ?? "").toLowerCase();
-      const nameB = (b.nome ?? "").toLowerCase();
-      if (nameA && nameB) return nameA.localeCompare(nameB);
-      return (a.tag ?? "").localeCompare(b.tag ?? "");
+      mapped.sort((a, b) => {
+        const nameA = (a.nome ?? "").toLowerCase();
+        const nameB = (b.nome ?? "").toLowerCase();
+        if (nameA && nameB) return nameA.localeCompare(nameB);
+        return (a.tag ?? "").localeCompare(b.tag ?? "");
+      });
+
+      return mapped;
     });
 
-    return NextResponse.json(results);
+    return NextResponse.json(results, {
+      headers: {
+        "Cache-Control": "private, max-age=60, stale-while-revalidate=120",
+      },
+    });
   } catch (error: unknown) {
     const message = error instanceof Error && error.message ? error.message : "INTERNAL_ERROR";
-    return NextResponse.json({ error: message }, { status: 500 });
+    const status = message === "MAINTAINER_NOT_FOUND" ? 403 : 500;
+    return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/me/programacoes/route.ts
+++ b/src/app/api/me/programacoes/route.ts
@@ -5,9 +5,10 @@ import { NextResponse } from "next/server";
 import { adminDb } from "@/lib/firebase-admin";
 import { requireMaint } from "@/lib/guards";
 import { normalizeName } from "@/lib/string-utils";
+import { getOrSetServerCache } from "@/lib/server-memory-cache";
 
 export const runtime = "nodejs";
-export const dynamic = "force-dynamic";
+export const revalidate = 60;
 
 function toIso(value: unknown) {
   if (typeof value === "string") return value;
@@ -36,8 +37,10 @@ export async function GET() {
     const maintId = auth.store.id ?? null;
     const maintName = auth.store.nome ?? null;
     const normalizedName = normalizeName(typeof maintName === "string" ? maintName : null);
+    const cacheKey = `me:programacoes:${maintId ?? "anon"}:${normalizedName ?? "sem-nome"}`;
 
-    const docsMap = new Map<string, DocumentSnapshot<DocumentData>>();
+    const results = await getOrSetServerCache(cacheKey, 60_000, async () => {
+      const docsMap = new Map<string, DocumentSnapshot<DocumentData>>();
 
     if (maintId) {
       const [principalSnap, idsSnap] = await Promise.all([
@@ -172,7 +175,14 @@ export async function GET() {
       };
     });
 
-    return NextResponse.json(results);
+      return results;
+    });
+
+    return NextResponse.json(results, {
+      headers: {
+        "Cache-Control": "private, max-age=60, stale-while-revalidate=120",
+      },
+    });
   } catch (error: unknown) {
     const message = error instanceof Error && error.message ? error.message : "INTERNAL_ERROR";
     return NextResponse.json({ error: message }, { status: 500 });

--- a/src/app/home/inspecoes/page.tsx
+++ b/src/app/home/inspecoes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useInfiniteQuery } from "@tanstack/react-query";
 
 type MaintInspectionListItem = {
   id: string;
@@ -14,7 +15,13 @@ type MaintInspectionListItem = {
   qtdNc: number;
 };
 
+type InspecoesResponse = {
+  items: MaintInspectionListItem[];
+  nextCursor: string | null;
+};
+
 const PAGE_LIMIT = 20;
+const cacheInspecoes = new Map<string, InspecoesResponse>();
 
 function formatDateTime(value: string | null) {
   if (!value) return "-";
@@ -23,18 +30,71 @@ function formatDateTime(value: string | null) {
   return date.toLocaleString("pt-BR");
 }
 
+async function fetchInspecoes(
+  appliedStart: string,
+  appliedEnd: string,
+  cursor?: string,
+): Promise<InspecoesResponse> {
+  const params = new URLSearchParams();
+  if (appliedStart.trim()) {
+    params.set("startDate", appliedStart.trim());
+  }
+  if (appliedEnd.trim()) {
+    params.set("endDate", appliedEnd.trim());
+  }
+  params.set("limit", String(PAGE_LIMIT));
+  if (cursor) {
+    params.set("cursor", cursor);
+  }
+
+  const cacheKey = `${appliedStart}|${appliedEnd}|${cursor ?? "first"}`;
+  const cached = cacheInspecoes.get(cacheKey);
+  if (cached) return cached;
+
+  const response = await fetch(`/api/me/inspecoes?${params.toString()}`, { cache: "force-cache" });
+
+  if (response.status === 401) {
+    if (typeof window !== "undefined") {
+      window.location.href = "/login";
+    }
+    throw new Error("UNAUTHENTICATED");
+  }
+
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    throw new Error(typeof payload?.error === "string" ? payload.error : "Falha ao carregar inspeções");
+  }
+
+  const data = await response.json();
+  const rawItems = Array.isArray(data?.items) ? (data.items as MaintInspectionListItem[]) : [];
+  const normalized = rawItems
+    .map(item => ({
+      id: item?.id ? String(item.id) : "",
+      machineTag: item?.machineTag ?? null,
+      machineNome: item?.machineNome ?? null,
+      machineSetor: item?.machineSetor ?? null,
+      machineUnidade: item?.machineUnidade ?? null,
+      finalizadaEm: item?.finalizadaEm ?? null,
+      osNumero: item?.osNumero ?? null,
+      qtdNc: Number.isFinite(item?.qtdNc) ? Number(item?.qtdNc) : 0,
+    }))
+    .filter(item => item.id);
+
+  const result = {
+    items: normalized,
+    nextCursor: data?.nextCursor ? String(data.nextCursor) : null,
+  };
+
+  cacheInspecoes.set(cacheKey, result);
+  return result;
+}
+
 export default function MaintCompletedInspectionsPage() {
   const router = useRouter();
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [appliedStart, setAppliedStart] = useState("");
   const [appliedEnd, setAppliedEnd] = useState("");
-  const [items, setItems] = useState<MaintInspectionListItem[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [initializing, setInitializing] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -54,83 +114,23 @@ export default function MaintCompletedInspectionsPage() {
     return null;
   }, [appliedEnd, appliedStart]);
 
-  const fetchInspections = useCallback(
-    async ({ reset, cursor }: { reset: boolean; cursor?: string }) => {
-      if (reset) {
-        setLoading(true);
-        setError(null);
-        setNextCursor(null);
-      } else {
-        setLoadingMore(true);
-      }
-      try {
-        const params = new URLSearchParams();
-        if (appliedStart.trim()) {
-          params.set("startDate", appliedStart.trim());
-        }
-        if (appliedEnd.trim()) {
-          params.set("endDate", appliedEnd.trim());
-        }
-        params.set("limit", String(PAGE_LIMIT));
-        if (cursor) {
-          params.set("cursor", cursor);
-        }
-        const response = await fetch(`/api/me/inspecoes?${params.toString()}`, { cache: "no-store" });
-        if (response.status === 401) {
-          window.location.href = "/login";
-          return;
-        }
-        if (!response.ok) {
-          const payload = await response.json().catch(() => null);
-          throw new Error(typeof payload?.error === "string" ? payload.error : "Falha ao carregar inspeções");
-        }
-        const data = await response.json();
-        const rawItems = Array.isArray(data?.items) ? (data.items as MaintInspectionListItem[]) : [];
-        const normalized = rawItems
-          .map(item => ({
-            id: item?.id ? String(item.id) : "",
-            machineTag: item?.machineTag ?? null,
-            machineNome: item?.machineNome ?? null,
-            machineSetor: item?.machineSetor ?? null,
-            machineUnidade: item?.machineUnidade ?? null,
-            finalizadaEm: item?.finalizadaEm ?? null,
-            osNumero: item?.osNumero ?? null,
-            qtdNc: Number.isFinite(item?.qtdNc) ? Number(item?.qtdNc) : 0,
-          }))
-          .filter(item => item.id);
-        setItems(prev => (reset ? normalized : [...prev, ...normalized]));
-        setNextCursor(data?.nextCursor ? String(data.nextCursor) : null);
-      } catch (err: unknown) {
-        const message = err instanceof Error && err.message ? err.message : "Falha ao carregar inspeções";
-        if (reset) {
-          setItems([]);
-          setError(message);
-        } else {
-          setError(message);
-        }
-      } finally {
-        if (reset) {
-          setLoading(false);
-          setInitializing(false);
-        } else {
-          setLoadingMore(false);
-        }
-      }
-    },
-    [appliedEnd, appliedStart]
-  );
+  const query = useInfiniteQuery({
+    queryKey: ["inspecoes", appliedStart, appliedEnd],
+    enabled: !dateError,
+    queryFn: ({ pageParam }) => fetchInspecoes(appliedStart, appliedEnd, pageParam as string | undefined),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: lastPage => lastPage.nextCursor ?? undefined,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    retry: 1,
+  });
 
-  useEffect(() => {
-    if (appliedStart && appliedEnd && appliedStart > appliedEnd) {
-      setItems([]);
-      setError("A data inicial deve ser anterior ou igual à data final.");
-      setLoading(false);
-      setLoadingMore(false);
-      setInitializing(false);
-      return;
-    }
-    fetchInspections({ reset: true }).catch(() => undefined);
-  }, [appliedEnd, appliedStart, fetchInspections]);
+  const items = useMemo(
+    () => query.data?.pages.flatMap(page => page.items) ?? [],
+    [query.data?.pages]
+  );
 
   const applyFilters = useCallback(() => {
     setAppliedStart(startDate.trim());
@@ -150,6 +150,10 @@ export default function MaintCompletedInspectionsPage() {
     },
     [router]
   );
+
+  const loading = query.isLoading;
+  const loadingMore = query.isFetchingNextPage;
+  const error = query.error instanceof Error ? query.error.message : null;
 
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 px-4 py-8">
@@ -211,10 +215,10 @@ export default function MaintCompletedInspectionsPage() {
             <h2 className="text-lg font-semibold text-slate-900">Histórico de inspeções</h2>
             <p className="text-sm text-slate-500">Toque para revisar as respostas ou gerar o PDF da inspeção finalizada.</p>
           </div>
-          {initializing ? null : <span className="text-xs text-slate-400">{items.length} inspeções listadas</span>}
+          {!loading ? <span className="text-xs text-slate-400">{items.length} inspeções listadas</span> : null}
         </header>
 
-        {loading && initializing ? (
+        {loading ? (
           <div className="grid gap-4 sm:grid-cols-2">
             {Array.from({ length: 4 }).map((_, index) => (
               <div key={index} className="h-36 animate-pulse rounded-2xl bg-slate-100" />
@@ -271,11 +275,11 @@ export default function MaintCompletedInspectionsPage() {
           </div>
         )}
 
-        {nextCursor && !loading && (
+        {query.hasNextPage && !loading && (
           <div className="flex justify-center">
             <button
               type="button"
-              onClick={() => fetchInspections({ reset: false, cursor: nextCursor }).catch(() => undefined)}
+              onClick={() => query.fetchNextPage()}
               disabled={loadingMore}
               className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
             >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { QueryProvider } from "@/components/query-provider";
 import { cn } from "@/lib/cn";
 import "./globals.css";
 
@@ -23,9 +24,11 @@ export default function RootLayout({
         />
       </head>
       <body className={cn("app-body antialiased")}> 
-        <div className="app-shell">
-          <div className="page-wrapper">{children}</div>
-        </div>
+        <QueryProvider>
+          <div className="app-shell">
+            <div className="page-wrapper">{children}</div>
+          </div>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/src/components/query-provider.tsx
+++ b/src/components/query-provider.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+export function QueryProvider({ children }: Props) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 1000 * 60 * 5,
+            gcTime: 1000 * 60 * 10,
+            refetchOnWindowFocus: false,
+            refetchOnReconnect: false,
+            refetchOnMount: false,
+            retry: 1,
+          },
+        },
+      })
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -2,7 +2,7 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
-import { getFirestore } from "firebase/firestore";
+import { getFirestore, initializeFirestore, persistentLocalCache } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
@@ -14,7 +14,14 @@ const firebaseConfig = {
 
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
+const db =
+  typeof window === "undefined"
+    ? getFirestore(app)
+    : initializeFirestore(app, {
+        localCache: persistentLocalCache(),
+      });
+
 export const firebaseApp = app;
 export const firebaseAuth = getAuth(app);
 export const firebaseStorage = getStorage(app);
-export const firebaseDb = getFirestore(app);
+export const firebaseDb = db;

--- a/src/lib/inspection-summary.ts
+++ b/src/lib/inspection-summary.ts
@@ -1,0 +1,74 @@
+import { adminDb } from "@/lib/firebase-admin";
+
+type InspectionSummaryInput = {
+  id: string;
+  createdAt: string;
+  machine: {
+    machineId: string | null;
+    tag: string | null;
+    nome: string | null;
+    setor: string | null;
+  };
+  maintainer: {
+    maintId: string | null;
+    nome: string | null;
+    matricula: string | null;
+  };
+  template: {
+    id: string | null;
+    nome: string | null;
+    versao?: string | null;
+  };
+  osNumero: string | null;
+  qtdNc: number;
+};
+
+function tokenize(value: string | null | undefined) {
+  if (!value) return [];
+  return value
+    .toLowerCase()
+    .split(/[^a-z0-9]+/i)
+    .map(token => token.trim())
+    .filter(Boolean)
+    .slice(0, 20);
+}
+
+export function buildInspectionSummary(input: InspectionSummaryInput) {
+  const machineTag = input.machine.tag?.trim() ?? null;
+  const machineNome = input.machine.nome?.trim() ?? null;
+  const machineSetor = input.machine.setor?.trim() ?? null;
+
+  return {
+    inspectionId: input.id,
+    createdAt: input.createdAt,
+    machineId: input.machine.machineId,
+    machineTag,
+    machineTagLower: machineTag?.toLowerCase() ?? null,
+    machineNome,
+    machineNomeLower: machineNome?.toLowerCase() ?? null,
+    machineSetor,
+    machineSetorLower: machineSetor?.toLowerCase() ?? null,
+    machineSearchTokens: Array.from(new Set([
+      ...(machineTag ? [machineTag.toLowerCase()] : []),
+      ...(input.machine.machineId ? [input.machine.machineId.toLowerCase()] : []),
+      ...tokenize(machineNome),
+      ...tokenize(machineSetor),
+    ])).slice(0, 30),
+    maintainerId: input.maintainer.maintId,
+    maintainerNome: input.maintainer.nome,
+    maintainerMatricula: input.maintainer.matricula,
+    maintainerMatriculaLower: input.maintainer.matricula?.toLowerCase() ?? null,
+    templateId: input.template.id,
+    templateNome: input.template.nome,
+    templateVersao: input.template.versao ?? null,
+    osNumero: input.osNumero,
+    qtdNc: input.qtdNc,
+    hasNc: input.qtdNc > 0,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+export async function upsertInspectionSummary(input: InspectionSummaryInput) {
+  const summary = buildInspectionSummary(input);
+  await adminDb.collection("inspecoes_resumo").doc(input.id).set(summary, { merge: true });
+}

--- a/src/lib/server-memory-cache.ts
+++ b/src/lib/server-memory-cache.ts
@@ -1,0 +1,35 @@
+type CacheEntry<T> = {
+  value: T;
+  expiresAt: number;
+};
+
+const serverCache = new Map<string, CacheEntry<unknown>>();
+
+export async function getOrSetServerCache<T>(
+  key: string,
+  ttlMs: number,
+  factory: () => Promise<T>
+): Promise<T> {
+  const now = Date.now();
+  const cached = serverCache.get(key);
+
+  if (cached && cached.expiresAt > now) {
+    return cached.value as T;
+  }
+
+  const value = await factory();
+  serverCache.set(key, {
+    value,
+    expiresAt: now + Math.max(ttlMs, 1000),
+  });
+
+  return value;
+}
+
+export function clearServerCacheByPrefix(prefix: string) {
+  for (const key of serverCache.keys()) {
+    if (key.startsWith(prefix)) {
+      serverCache.delete(key);
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Reduce client-side Firestore reads and heavy in-browser filtering by moving lookups and filters to server endpoints. 
- Improve API performance for list endpoints via server-side pagination, filtering and caching to speed up admin and maintainer views. 
- Provide consistent caching and background refetch behavior on the client with `react-query` and enable Firestore's persistent local cache in browser. 

### Description
- Reworked admin UI to fetch lookups (`machines`, `mantenedores`, `templates`) and checklist lists via new/updated API endpoints instead of direct Firestore reads, and moved most filter logic into the backend (`/api/admin/checklists`).
- Implemented a paginated, server-side filterable scanner in `api/admin/checklists/route.ts` with date range handling, NC computation (`computeNcCount`), batched Firestore reads and `hasMore`/`nextOffset` semantics.
- Enhanced `api/admin/nc/route.ts` to support `machine_query` filtering, chunked document retrieval (`getDocumentsByIds`), template resolution, and narrowed treatment payloads returned only for the paginated page.
- Added server in-memory caching helper `src/lib/server-memory-cache.ts` and applied caching and cache-control headers to several "me" endpoints (`me/inspecoes`, `me/machines`, `me/programacoes`) to reduce repeated backend work.
- Converted maintainer inspections UI (`src/app/home/inspecoes/page.tsx`) to use `react-query`'s `useInfiniteQuery` with a small client cache and added a `QueryProvider` component injected in the root layout for global query client defaults.
- Updated client Firestore initialization (`src/lib/firebase-client.ts`) to enable `persistentLocalCache()` in the browser and kept server behavior unchanged.
- Adjusted various client behaviors: removed redundant client-side filter application in admin checklists, passed filters as query params to the backend, and fixed delete logic to use `doc(firebaseDb, inspectionsCol.id, row.id)`.

### Testing
- Ran TypeScript type-check and project build (Next.js) locally and the build completed successfully. 
- Ran lint/type validation in CI (pre-commit) and no new lint errors were reported. 
- No new unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0cacd3874832886e228932674197c)