### PR TITLE
revert: restaurar tela de NC em admin para o estado de f8262dd

### DIFF
--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -6,7 +6,11 @@ import {
   collection,
   deleteField,
   doc,
+  getDoc,
+  getDocs,
+  query,
   updateDoc,
+  where,
 } from "firebase/firestore";
 import { firebaseDb } from "@/lib/firebase-client";
 import { Button } from "@/components/ui/button";
@@ -17,13 +21,35 @@ import { Select } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import type {
+  ChecklistAnswer,
   ChecklistNonConformityTreatment,
   NonConformityStatus,
   StoredImage,
 } from "@/types";
-import { sortByLastActivityDesc } from "@/lib/non-conformity-priority";
+import { resolveIssueLastActivityAt, sortByLastActivityDesc } from "@/lib/non-conformity-priority";
+import { normalizeStoredImages } from "@/lib/storage/images";
+
+interface MachineOption {
+  id: string;
+  nome: string;
+  tag?: string | null;
+  templateId?: string | null;
+  ativo?: boolean;
+}
+
+interface TemplateItemData {
+  id?: string;
+  componente?: string;
+  criterio?: string;
+  oQueChecar?: string;
+}
+
+interface TemplateMeta {
+  nome?: string | null;
+  versao?: string | null;
+  itensMap: Map<string, TemplateItemData>;
+}
 
 interface NonConformityItem {
   id: string;
@@ -50,18 +76,8 @@ interface NonConformityItem {
   dueDateIso: string | null;
   recurrence: boolean;
   reincidenciaCount: number;
-  recurrenceHistory: NonConformityRecurrenceHistoryItem[];
   maintainerResolution: MaintainerResolutionInfo | null;
   updatedAt: string | null;
-}
-
-interface NonConformityRecurrenceHistoryItem {
-  inspectionId: string;
-  checklistDate: string | null;
-  observation: string | null;
-  osNumero: string | null;
-  osStatus: string | null;
-  operatorNome: string | null;
 }
 
 interface MaintainerResolutionInfo {
@@ -71,6 +87,21 @@ interface MaintainerResolutionInfo {
   description: string;
   osNumero: string | null;
   inspecaoId: string | null;
+}
+
+interface SourceInspectionData {
+  machineId: string | null;
+  machineLabel: string;
+  machineTag: string | null;
+  templateId: string | null;
+  templateLabel: string;
+  templateVersion: string | null;
+  checklistDate: string | null;
+  operatorNome: string | null;
+  operatorMatricula: string | null;
+  treatments: ChecklistNonConformityTreatment[];
+  treatmentMap: Map<string, ChecklistNonConformityTreatment>;
+  answersMap: Map<string, ChecklistAnswer>;
 }
 
 interface FeedbackState {
@@ -83,6 +114,128 @@ function formatDateTime(value: string | null | undefined) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "-";
   return date.toLocaleString("pt-BR");
+}
+
+function formatDateInput(value: string | null | undefined) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toISOString().slice(0, 10);
+}
+
+function normalizeStatus(value: unknown): NonConformityStatus | null {
+  if (value === "open" || value === "in_progress" || value === "resolved") {
+    return value;
+  }
+  return null;
+}
+
+function dedupeAnswers(answers: ChecklistAnswer[]) {
+  const seen = new Set<string>();
+  const unique: ChecklistAnswer[] = [];
+  answers.forEach(answer => {
+    if (!answer.questionId || seen.has(answer.questionId)) {
+      return;
+    }
+    seen.add(answer.questionId);
+    unique.push(answer);
+  });
+  return unique;
+}
+
+function mergeStoredImageCollections(...collections: unknown[]): StoredImage[] {
+  const seen = new Set<string>();
+  const merged: StoredImage[] = [];
+  collections.forEach(collection => {
+    normalizeStoredImages(collection).forEach(image => {
+      const key = `${image.provider}:${image.url}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      merged.push(image);
+    });
+  });
+  return merged;
+}
+
+function normalizeAnswers(
+  data: Record<string, unknown>,
+  templateItems: Map<string, TemplateItemData>
+): ChecklistAnswer[] {
+  const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  const answersFromItens = dedupeAnswers(
+    itens
+      .filter(item => item?.templateItemId)
+      .map(item => {
+        const questionId = String(item.templateItemId);
+        const templateItem = templateItems.get(questionId) ?? {};
+        const resultado = String(item.resultado || "C").toLowerCase();
+        const response: "c" | "nc" | "na" = resultado === "nc" ? "nc" : resultado === "na" ? "na" : "c";
+        return {
+          questionId,
+          questionText:
+            templateItem.oQueChecar ||
+            templateItem.criterio ||
+            templateItem.componente ||
+            (typeof item.componente === "string" ? item.componente : `Item ${questionId}`),
+          response,
+          observation: typeof item.observacaoItem === "string" ? item.observacaoItem : null,
+          photoUrls: normalizeStoredImages(item.fotos ?? []),
+          recurrence: false,
+          itemOsNumero: typeof item.osNumeroItem === "string" && item.osNumeroItem.trim()
+            ? item.osNumeroItem.trim().toUpperCase()
+            : null,
+        } satisfies ChecklistAnswer;
+      })
+  );
+
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length === 0) {
+    return answersFromItens;
+  }
+
+  const answersFromItensByQuestionId = new Map(
+    answersFromItens.map(answer => [answer.questionId, answer] as const)
+  );
+  const answersFromPayload = dedupeAnswers(
+    answers
+      .filter(item => item?.questionId)
+      .map(item => {
+        const fallbackFromItens = answersFromItensByQuestionId.get(item.questionId);
+        return {
+          questionId: item.questionId,
+          questionText:
+            item.questionText ||
+            templateItems.get(item.questionId)?.oQueChecar ||
+            templateItems.get(item.questionId)?.criterio ||
+            templateItems.get(item.questionId)?.componente ||
+            fallbackFromItens?.questionText ||
+            `Item ${item.questionId}`,
+          response: item.response === "nc" || item.response === "na" ? item.response : "c",
+          observation: item.observation ?? fallbackFromItens?.observation ?? null,
+          photoUrls: mergeStoredImageCollections(item.photoUrls, fallbackFromItens?.photoUrls),
+          recurrence: item.recurrence === true || fallbackFromItens?.recurrence === true,
+          itemOsNumero: item.itemOsNumero ?? fallbackFromItens?.itemOsNumero ?? null,
+        } satisfies ChecklistAnswer;
+      })
+  );
+
+  const questionIdsFromPayload = new Set(answersFromPayload.map(item => item.questionId));
+  const missingFromPayload = answersFromItens.filter(item => !questionIdsFromPayload.has(item.questionId));
+  return dedupeAnswers([...answersFromPayload, ...missingFromPayload]);
+}
+
+function buildMachineLabel(machine: Record<string, unknown>) {
+  const nome = machine?.nome ? String(machine.nome) : "Máquina";
+  const tag = machine?.tag ? String(machine.tag) : null;
+  return tag ? `${nome} (${tag})` : nome;
+}
+
+function buildMachineLabelFromOption(machine: MachineOption | undefined, fallbackTag?: string | null) {
+  if (!machine) {
+    return fallbackTag ? `Máquina (${fallbackTag})` : "Máquina";
+  }
+  const tag = machine.tag ?? fallbackTag ?? null;
+  return tag ? `${machine.nome} (${tag})` : machine.nome;
 }
 
 function renderStatusBadge(status: NonConformityStatus) {
@@ -109,9 +262,6 @@ export default function AdminNonConformitiesPage() {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkSaving, setBulkSaving] = useState(false);
   const [expandedResolutions, setExpandedResolutions] = useState<Set<string>>(new Set());
-  const [expandedHistory, setExpandedHistory] = useState<Set<string>>(new Set());
-  const [deleteDialogItemId, setDeleteDialogItemId] = useState<string | null>(null);
-  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
     setSelectedIds(prev => prev.filter(id => items.some(item => item.id === id)));
@@ -121,20 +271,242 @@ export default function AdminNonConformitiesPage() {
     setLoading(true);
     setError(null);
     try {
-      const session = await fetch("/api/admin/nc", { cache: "no-store" });
+      const session = await fetch("/api/admin-session", { cache: "no-store" });
       if (session.status === 401) {
         window.location.href = "/admin/login";
         return;
       }
-      if (!session.ok) {
-        throw new Error("Falha ao carregar não conformidades.");
-      }
-      const payload = (await session.json()) as {
-        items?: NonConformityItem[];
-        treatmentsByResponse?: Record<string, ChecklistNonConformityTreatment[]>;
-      };
-      setItems(sortByLastActivityDesc(payload.items ?? []));
-      setTreatmentsByResponse(payload.treatmentsByResponse ?? {});
+
+      const [machinesSnap, templatesSnap, issuesSnap] = await Promise.all([
+        getDocs(collection(firebaseDb, "machines")),
+        getDocs(collection(firebaseDb, "templates")),
+        getDocs(query(collection(firebaseDb, "issues"), where("status", "in", ["aberta", "concluida", "resolvida"]))),
+      ]);
+
+      const machineOptions: MachineOption[] = machinesSnap.docs.map(docSnap => {
+        const data = docSnap.data() ?? {};
+        return {
+          id: docSnap.id,
+          nome: typeof data.nome === "string" ? data.nome : docSnap.id,
+          tag: data.tag ? String(data.tag) : null,
+          templateId: typeof data.templateId === "string" ? data.templateId : null,
+          ativo: data.ativo !== false,
+        } satisfies MachineOption;
+      });
+      const machinesById = new Map(machineOptions.map(machine => [machine.id, machine]));
+
+      const templateMap = new Map<string, TemplateMeta>();
+      templatesSnap.docs.forEach(docSnap => {
+        const data = docSnap.data() ?? {};
+        const itens = Array.isArray(data.itens) ? (data.itens as TemplateItemData[]) : [];
+        const itensMap = new Map<string, TemplateItemData>();
+        itens.forEach(item => {
+          if (item?.id) {
+            itensMap.set(String(item.id), item);
+          }
+        });
+        templateMap.set(docSnap.id, {
+          nome: data.nome ? String(data.nome) : docSnap.id,
+          versao: data.versao ? String(data.versao) : null,
+          itensMap,
+        });
+      });
+
+      const sourceInspectionIds = Array.from(
+        new Set(
+          issuesSnap.docs
+            .map(issueDoc => {
+              const issueData = issueDoc.data() ?? {};
+              return typeof issueData.abertaEmInspecaoId === "string"
+                ? issueData.abertaEmInspecaoId
+                : null;
+            })
+            .filter((value): value is string => Boolean(value))
+        )
+      );
+
+      const sourceInspectionEntries = await Promise.all(
+        sourceInspectionIds.map(async inspectionId => {
+          const inspectionRef = doc(collection(firebaseDb, "inspecoes"), inspectionId);
+          const inspectionSnap = await getDoc(inspectionRef);
+          if (!inspectionSnap.exists()) {
+            return [inspectionId, null] as const;
+          }
+
+          const inspectionData = inspectionSnap.data() ?? {};
+          const machine = (inspectionData.machine ?? {}) as Record<string, unknown>;
+          const maintainer = (inspectionData.maintainer ?? {}) as Record<string, unknown>;
+          const templateInfo = (inspectionData.template ?? {}) as Record<string, unknown>;
+          const templateId =
+            typeof templateInfo.id === "string"
+              ? templateInfo.id
+              : typeof machine.templateId === "string"
+              ? machine.templateId
+              : null;
+          const templateMeta = templateId ? templateMap.get(templateId) : undefined;
+          const answers = normalizeAnswers(inspectionData, templateMeta?.itensMap ?? new Map());
+          const answersMap = new Map(answers.map(answer => [answer.questionId, answer]));
+          const treatments = Array.isArray(inspectionData.nonConformityTreatments)
+            ? (inspectionData.nonConformityTreatments as ChecklistNonConformityTreatment[])
+            : [];
+          const treatmentMap = new Map<string, ChecklistNonConformityTreatment>();
+          treatments.forEach(treatment => {
+            if (treatment?.questionId) {
+              treatmentMap.set(treatment.questionId, treatment);
+            }
+          });
+
+          return [
+            inspectionId,
+            {
+              machineId:
+                typeof machine.machineId === "string"
+                  ? machine.machineId
+                  : typeof machine.id === "string"
+                  ? machine.id
+                  : null,
+              machineLabel: buildMachineLabel(machine),
+              machineTag: typeof machine.tag === "string" ? machine.tag : null,
+              templateId,
+              templateLabel:
+                templateMeta?.nome ??
+                (typeof templateInfo.nome === "string" ? String(templateInfo.nome) : "Template"),
+              templateVersion:
+                templateMeta?.versao ??
+                (typeof templateInfo.versao === "string" ? String(templateInfo.versao) : null),
+              checklistDate:
+                typeof inspectionData.createdAt === "string"
+                  ? inspectionData.createdAt
+                  : typeof inspectionData.finalizadaEm === "string"
+                  ? inspectionData.finalizadaEm
+                  : null,
+              operatorNome: typeof maintainer.nome === "string" ? maintainer.nome : null,
+              operatorMatricula: typeof maintainer.matricula === "string" ? maintainer.matricula : null,
+              treatments,
+              treatmentMap,
+              answersMap,
+            } satisfies SourceInspectionData,
+          ] as const;
+        })
+      );
+
+      const sourceInspectionMap = new Map<string, SourceInspectionData>();
+      const treatmentsRecord: Record<string, ChecklistNonConformityTreatment[]> = {};
+      sourceInspectionEntries.forEach(([inspectionId, inspectionData]) => {
+        if (!inspectionData) return;
+        sourceInspectionMap.set(inspectionId, inspectionData);
+        treatmentsRecord[inspectionId] = inspectionData.treatments;
+      });
+
+      const builtItems: NonConformityItem[] = [];
+      issuesSnap.docs.forEach(issueDoc => {
+        const issueData = issueDoc.data() ?? {};
+        const machineId = typeof issueData.machineId === "string" ? issueData.machineId : null;
+        const questionId = typeof issueData.templateItemId === "string" ? issueData.templateItemId : null;
+        if (!questionId) return;
+
+        const responseId =
+          typeof issueData.abertaEmInspecaoId === "string" ? issueData.abertaEmInspecaoId : null;
+        const sourceInspection = responseId ? sourceInspectionMap.get(responseId) : undefined;
+        const machineOption = machineId ? machinesById.get(machineId) : undefined;
+        const issueTag = typeof issueData.tag === "string" ? issueData.tag : null;
+        const templateId = sourceInspection?.templateId ?? machineOption?.templateId ?? null;
+        const templateMeta = templateId ? templateMap.get(templateId) : undefined;
+        const templateItem = templateMeta?.itensMap.get(questionId);
+        const answerData = sourceInspection?.answersMap.get(questionId);
+
+        const rawIssueTreatment =
+          issueData.pcmTreatment && typeof issueData.pcmTreatment === "object"
+            ? (issueData.pcmTreatment as Record<string, unknown>)
+            : null;
+        const sourceTreatment = sourceInspection?.treatmentMap.get(questionId);
+        const issueStatus =
+          issueData.status === "resolvida"
+            ? "resolvida"
+            : issueData.status === "concluida"
+            ? "concluida"
+            : "aberta";
+        const statusFromTreatment = normalizeStatus(rawIssueTreatment?.status ?? sourceTreatment?.status);
+        const status: NonConformityStatus =
+          issueStatus === "aberta" ? statusFromTreatment ?? "open" : "resolved";
+
+        const summaryValue =
+          typeof rawIssueTreatment?.summary === "string"
+            ? rawIssueTreatment.summary
+            : sourceTreatment?.summary ?? null;
+        const responsibleValue =
+          typeof rawIssueTreatment?.responsible === "string"
+            ? rawIssueTreatment.responsible
+            : sourceTreatment?.responsible ?? null;
+        const dueDateIsoValue =
+          typeof rawIssueTreatment?.dueDate === "string"
+            ? rawIssueTreatment.dueDate
+            : sourceTreatment?.dueDate ?? null;
+        const updatedAtValue = resolveIssueLastActivityAt({
+          issueData,
+          rawIssueTreatment,
+          sourceTreatment,
+        });
+
+        const rawResolution = issueData.maintainerResolution ?? null;
+        const maintainerResolution = rawResolution && typeof rawResolution === "object"
+          ? {
+              resolvedAt: rawResolution.resolvedAt ?? null,
+              resolvedByName: rawResolution.resolvedByName ?? null,
+              resolvedByMatricula: rawResolution.resolvedByMatricula ?? null,
+              description: typeof rawResolution.description === "string" ? rawResolution.description : "",
+              osNumero: rawResolution.osNumero ?? null,
+              inspecaoId: rawResolution.inspecaoId ?? null,
+            }
+          : null;
+        const reincidenciaCount = typeof issueData.reincidenciaCount === "number" ? issueData.reincidenciaCount : 0;
+
+        builtItems.push({
+          id: issueDoc.id,
+          responseId,
+          questionId,
+          machineId: machineId ?? sourceInspection?.machineId ?? null,
+          machineLabel:
+            sourceInspection?.machineLabel ?? buildMachineLabelFromOption(machineOption, issueTag),
+          machineTag: sourceInspection?.machineTag ?? machineOption?.tag ?? issueTag,
+          templateId,
+          templateLabel: sourceInspection?.templateLabel ?? templateMeta?.nome ?? "Template",
+          templateVersion: sourceInspection?.templateVersion ?? templateMeta?.versao ?? null,
+          questionText:
+            answerData?.questionText ??
+            templateItem?.oQueChecar ??
+            templateItem?.criterio ??
+            templateItem?.componente ??
+            `Item ${questionId}`,
+          checklistDate:
+            sourceInspection?.checklistDate ??
+            (typeof issueData.createdAt === "string" ? issueData.createdAt : null),
+          operatorNome: sourceInspection?.operatorNome ?? null,
+          operatorMatricula: sourceInspection?.operatorMatricula ?? null,
+          observation:
+            typeof issueData.descricao === "string"
+              ? issueData.descricao
+              : answerData?.observation ?? null,
+          photos: mergeStoredImageCollections(issueData.fotos, answerData?.photoUrls),
+          itemOsNumero:
+            typeof issueData.osNumero === "string"
+              ? issueData.osNumero
+              : answerData?.itemOsNumero ?? null,
+          issueStatus,
+          status,
+          summary: summaryValue ? String(summaryValue) : "",
+          responsible: responsibleValue ? String(responsibleValue) : "",
+          dueDate: formatDateInput(dueDateIsoValue),
+          dueDateIso: dueDateIsoValue ? String(dueDateIsoValue) : null,
+          recurrence: answerData?.recurrence ?? reincidenciaCount > 0,
+          reincidenciaCount,
+          maintainerResolution,
+          updatedAt: updatedAtValue,
+        });
+      });
+
+      setItems(sortByLastActivityDesc(builtItems));
+      setTreatmentsByResponse(treatmentsRecord);
     } catch (err: unknown) {
       const message = err instanceof Error && err.message ? err.message : "Erro ao carregar dados";
       setError(message);
@@ -323,40 +695,6 @@ export default function AdminNonConformitiesPage() {
     });
   }, []);
 
-  const handleToggleHistory = useCallback((itemId: string) => {
-    setExpandedHistory(prev => {
-      const next = new Set(prev);
-      if (next.has(itemId)) {
-        next.delete(itemId);
-      } else {
-        next.add(itemId);
-      }
-      return next;
-    });
-  }, []);
-
-  const handleDeleteItem = useCallback(async () => {
-    if (!deleteDialogItemId) return;
-    setDeletingId(deleteDialogItemId);
-    try {
-      const response = await fetch(`/api/admin/nc/${deleteDialogItemId}`, {
-        method: "DELETE",
-      });
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({}));
-        throw new Error(payload?.error || "Não foi possível excluir a não conformidade.");
-      }
-      setItems(prev => prev.filter(item => item.id !== deleteDialogItemId));
-      setSelectedIds(prev => prev.filter(id => id !== deleteDialogItemId));
-      setDeleteDialogItemId(null);
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Erro ao excluir não conformidade";
-      setError(message);
-    } finally {
-      setDeletingId(null);
-    }
-  }, [deleteDialogItemId]);
-
   const allVisibleSelected =
     filteredItems.length > 0 && filteredItems.every(item => selectedIds.includes(item.id));
   const selectedCount = selectedIds.length;
@@ -513,9 +851,6 @@ export default function AdminNonConformitiesPage() {
             const hasMaintainerResolution = item.maintainerResolution != null;
             const reincidenciaCount = item.reincidenciaCount;
             const isResolutionExpanded = expandedResolutions.has(item.id);
-            const hasHistory = item.recurrenceHistory.length > 0;
-            const isHistoryExpanded = expandedHistory.has(item.id);
-            const visibleHistory = isHistoryExpanded ? item.recurrenceHistory : item.recurrenceHistory.slice(0, 3);
             return (
               <article key={item.id}>
                 <Card>
@@ -680,52 +1015,11 @@ export default function AdminNonConformitiesPage() {
                       </div>
                     </section>
 
-                    <section className="space-y-3">
-                      <h3 className="text-sm font-semibold text-[var(--text)]">Histórico de reincidências</h3>
-                      {!hasHistory ? (
-                        <p className="text-sm text-[var(--muted)]">Sem histórico anterior.</p>
-                      ) : (
-                        <div className="divide-y divide-[var(--border)] rounded-lg border border-[var(--border)] bg-white">
-                          {visibleHistory.map(historyItem => (
-                            <div key={`${item.id}-${historyItem.inspectionId}`} className="space-y-1 px-3 py-2">
-                              <p className="text-xs text-[var(--muted)]">
-                                {formatDateTime(historyItem.checklistDate)}
-                                {historyItem.operatorNome ? ` · ${historyItem.operatorNome}` : ""}
-                              </p>
-                              <p className="text-sm text-[var(--text)]">{historyItem.observation || "-"}</p>
-                              <p className="text-xs text-[var(--muted)]">
-                                O.S.: {historyItem.osNumero || "-"}
-                                {historyItem.osStatus ? ` · Status: ${historyItem.osStatus}` : ""}
-                              </p>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                      {item.recurrenceHistory.length > 3 && (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          className="h-auto px-0 py-1 text-xs"
-                          onClick={() => handleToggleHistory(item.id)}
-                        >
-                          {isHistoryExpanded ? "Exibir apenas 3 últimas" : "Exibir histórico completo"}
-                        </Button>
-                      )}
-                    </section>
-
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                       <div className="text-sm text-[var(--muted)]">
                         {item.updatedAt ? `Atualizado em ${formatDateTime(item.updatedAt)}` : "Tratativa ainda não salva"}
                       </div>
                       <div className="flex items-center gap-3">
-                        <Button
-                          type="button"
-                          variant="destructive"
-                          onClick={() => setDeleteDialogItemId(item.id)}
-                          disabled={bulkSaving || deletingId === item.id}
-                        >
-                          Excluir NC
-                        </Button>
                         <Button
                           onClick={() => handleSave(item)}
                           loading={savingId === item.id}
@@ -753,19 +1047,6 @@ export default function AdminNonConformitiesPage() {
           })}
         </div>
       )}
-      <ConfirmDialog
-        open={deleteDialogItemId != null}
-        title="Excluir não conformidade?"
-        description="Essa ação remove o card da NC e não poderá ser desfeita."
-        confirmLabel="Excluir NC"
-        cancelLabel="Cancelar"
-        busy={deletingId != null}
-        onCancel={() => {
-          if (deletingId) return;
-          setDeleteDialogItemId(null);
-        }}
-        onConfirm={handleDeleteItem}
-      />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Restaurar o comportamento anterior da tela de Não Conformidades em `src/app/admin/nc/page.tsx` revertendo mudanças introduzidas após o ponto solicitado porque as alterações posteriores modificaram carregamento de dados e recursos de histórico/exclusão.

### Description
- Substitui `src/app/admin/nc/page.tsx` pelo estado presente no commit solicitado, restaurando interfaces, helpers e lógica de construção dos itens exibidos na lista de NC.
- Removeu as mudanças introduzidas após esse ponto, incluindo o diálogo de exclusão de NC e o fluxo de remoção, a seção de histórico de reincidências e os estados/handlers relacionados à exclusão e expansão do histórico.
- Restaura a lógica anterior de carregamento e normalização dos dados (resolução de máquina/template, união de imagens e mapeamento de tratamentos) utilizada pela tela administrativa.

### Testing
- Inspecionei o estado do repositório e o histórico recente para localizar o ponto alvo e confirmei que a restauração do arquivo foi aplicada corretamente.
- Gravei a alteração restaurada como uma nova mudança e verifiquei o resumo de diff/stat para confirmar que o único arquivo modificado foi `src/app/admin/nc/page.tsx` com as inserções/remoções esperadas.
- Criei a PR de acompanhamento via a ferramenta de criação de PRs para registrar a reversão.
- Não foram executados testes automatizados unitários ou de integração além das verificações do repositório e do diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e217580e488330858d5c7f5e9ab240)