### PR TITLE
feat(admin/nc): add 'Excluir tratativa' action with confirmation dialog

### DIFF
--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -21,6 +21,7 @@ import { Select } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import type {
   ChecklistAnswer,
   ChecklistNonConformityTreatment,
@@ -262,6 +263,8 @@ export default function AdminNonConformitiesPage() {
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [bulkSaving, setBulkSaving] = useState(false);
   const [expandedResolutions, setExpandedResolutions] = useState<Set<string>>(new Set());
+  const [deleteCandidate, setDeleteCandidate] = useState<NonConformityItem | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
     setSelectedIds(prev => prev.filter(id => items.some(item => item.id === id)));
@@ -695,6 +698,55 @@ export default function AdminNonConformitiesPage() {
     });
   }, []);
 
+  const handleDeleteTreatment = useCallback(async () => {
+    if (!deleteCandidate) return;
+
+    const item = deleteCandidate;
+    setDeletingId(item.id);
+    setFeedback(prev => ({ ...prev, [item.id]: { type: "success", message: "" } }));
+
+    try {
+      const nowIso = new Date().toISOString();
+
+      if (item.responseId) {
+        const existing = treatmentsByResponse[item.responseId] ?? [];
+        const nextTreatments = existing.filter(treatment => treatment.questionId !== item.questionId);
+
+        await updateDoc(doc(collection(firebaseDb, "inspecoes"), item.responseId), {
+          nonConformityTreatments: nextTreatments,
+          updatedAt: nowIso,
+        });
+
+        setTreatmentsByResponse(prev => ({ ...prev, [item.responseId as string]: nextTreatments }));
+      }
+
+      await updateDoc(doc(collection(firebaseDb, "issues"), item.id), {
+        pcmTreatment: deleteField(),
+        status: "aberta",
+        concluidaEm: deleteField(),
+        concluidaPorTratativa: deleteField(),
+        updatedAt: nowIso,
+      });
+
+      handleUpdateItem(item.id, {
+        summary: "",
+        responsible: "",
+        dueDate: "",
+        dueDateIso: null,
+        status: "open",
+        issueStatus: "aberta",
+        updatedAt: nowIso,
+      });
+      setFeedback(prev => ({ ...prev, [item.id]: { type: "success", message: "Tratativa excluída com sucesso" } }));
+      setDeleteCandidate(null);
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Erro ao excluir tratativa";
+      setFeedback(prev => ({ ...prev, [item.id]: { type: "error", message } }));
+    } finally {
+      setDeletingId(null);
+    }
+  }, [deleteCandidate, handleUpdateItem, treatmentsByResponse]);
+
   const allVisibleSelected =
     filteredItems.length > 0 && filteredItems.every(item => selectedIds.includes(item.id));
   const selectedCount = selectedIds.length;
@@ -1023,9 +1075,17 @@ export default function AdminNonConformitiesPage() {
                         <Button
                           onClick={() => handleSave(item)}
                           loading={savingId === item.id}
-                          disabled={bulkSaving}
+                          disabled={bulkSaving || deletingId === item.id}
                         >
                           Salvar tratativa
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          disabled={bulkSaving || savingId === item.id || deletingId === item.id}
+                          onClick={() => setDeleteCandidate(item)}
+                        >
+                          Excluir tratativa
                         </Button>
                         {itemFeedback?.message && (
                           <span
@@ -1047,6 +1107,20 @@ export default function AdminNonConformitiesPage() {
           })}
         </div>
       )}
+
+      <ConfirmDialog
+        open={deleteCandidate != null}
+        title="Excluir tratativa"
+        description="Deseja realmente excluir esta tratativa? Esta ação remove o planejamento salvo para esta NC."
+        confirmLabel="Excluir"
+        cancelLabel="Cancelar"
+        busy={deletingId != null}
+        onCancel={() => {
+          if (deletingId) return;
+          setDeleteCandidate(null);
+        }}
+        onConfirm={handleDeleteTreatment}
+      />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Provide a way for admins to delete a previously saved treatment for a non-conformity (NC) from the `/admin/nc` screen and ensure the action is confirmed by the user.

### Description
- Import `ConfirmDialog` and add component-level state `deleteCandidate` and `deletingId` to track the candidate NC and deletion progress.
- Implement `handleDeleteTreatment` to remove the treatment from the related `inspecoes` document, clear `pcmTreatment` and related fields on the `issues` document, update local UI state, and surface success/error feedback.
- Add a destructive `Excluir tratativa` button alongside `Salvar tratativa` on each NC card and disable relevant controls while delete/save operations are in progress.
- Render a confirmation modal (`ConfirmDialog`) before performing the deletion to prevent accidental removals.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it succeeded.
- Ran `npm run lint -- src/app/admin/nc/page.tsx` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e913d67d388330b8e4df2d39862221)