### PR TITLE
Non-conformities: update status filters and last-activity calculation

### DIFF
--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -257,7 +257,7 @@ export default function AdminNonConformitiesPage() {
   const [items, setItems] = useState<NonConformityItem[]>([]);
   const [treatmentsByResponse, setTreatmentsByResponse] = useState<Record<string, ChecklistNonConformityTreatment[]>>({});
   const [machineFilter, setMachineFilter] = useState("");
-  const [statusFilter, setStatusFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("open");
   const [savingId, setSavingId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Record<string, FeedbackState>>({});
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -543,23 +543,24 @@ export default function AdminNonConformitiesPage() {
           return false;
         }
       }
-      if (statusFilter === "pending") {
-        return item.status !== "resolved";
-      }
       if (statusFilter === "planned") {
         return Boolean(item.summary.trim() || item.responsible.trim() || item.dueDate);
       }
+      if (statusFilter === "unplanned") {
+        return !Boolean(item.summary.trim() || item.responsible.trim() || item.dueDate);
+      }
       if (statusFilter === "all") {
         return true;
+      }
+      if (statusFilter === "maintainer_resolved") {
+        return item.maintainerResolution != null;
       }
       return item.status === statusFilter;
     });
   }, [items, machineFilter, statusFilter]);
 
   const handleUpdateItem = useCallback((id: string, updates: Partial<NonConformityItem>) => {
-    setItems(prev =>
-      sortByLastActivityDesc(prev.map(item => (item.id === id ? { ...item, ...updates } : item)))
-    );
+    setItems(prev => prev.map(item => (item.id === id ? { ...item, ...updates } : item)));
   }, []);
 
   const handleSave = useCallback(
@@ -811,12 +812,12 @@ export default function AdminNonConformitiesPage() {
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Status</span>
             <Select value={statusFilter} onChange={event => setStatusFilter(event.target.value)}>
-              <option value="pending">Pendentes</option>
               <option value="planned">Com tratativa planejada</option>
+              <option value="unplanned">Sem tratativa planejada</option>
               <option value="all">Todos</option>
               <option value="open">Abertas</option>
-              <option value="in_progress">Em andamento</option>
               <option value="resolved">Resolvidas</option>
+              <option value="maintainer_resolved">Realizado pelo mantenedor</option>
             </Select>
           </label>
         </CardContent>

--- a/src/lib/non-conformity-priority.ts
+++ b/src/lib/non-conformity-priority.ts
@@ -53,14 +53,18 @@ export function resolveIssueLastActivityAt({
   rawIssueTreatment,
   sourceTreatment,
 }: IssueActivityAtInput): string | null {
+  void rawIssueTreatment;
+  void sourceTreatment;
+
+  const maintainerResolution =
+    issueData.maintainerResolution && typeof issueData.maintainerResolution === "object"
+      ? (issueData.maintainerResolution as Record<string, unknown>)
+      : null;
+
   const candidates: Array<unknown> = [
     issueData.ultimaOcorrenciaEm,
     issueData.ultimaReincidenciaEm,
-    issueData.updatedAt,
-    rawIssueTreatment?.updatedAt,
-    sourceTreatment?.updatedAt,
-    rawIssueTreatment?.createdAt,
-    sourceTreatment?.createdAt,
+    maintainerResolution?.resolvedAt,
     issueData.concluidaEm,
     issueData.createdAt,
   ];


### PR DESCRIPTION
### Motivation
- Improve admin NC filtering to show open items by default and add explicit options for planned vs unplanned treatments and maintainer-resolved items.
- Make last-activity calculation consider maintainer resolution timestamps and avoid relying on possibly-undefined treatment objects.
- Address a lint/behavior issue by not re-sorting the UI list when an individual item is updated.

### Description
- Set default `statusFilter` to `"open"` in `src/app/admin/nc/page.tsx` so the page opens showing open non-conformities.
- Replace the removed `pending` filter with two explicit filters: `unplanned` (no planned treatment) and `maintainer_resolved` (items with `maintainerResolution`), and keep `planned` and `all` options; update the `<Select>` options accordingly.
- Adjust `filteredItems` logic to implement `planned` as items with a summary/responsible/due date, `unplanned` as the negation, and `maintainer_resolved` as items where `maintainerResolution` is present.
- Stop sorting items on every single-item update by removing `sortByLastActivityDesc` from `handleUpdateItem` so updates preserve the current list order.
- In `src/lib/non-conformity-priority.ts`, update `resolveIssueLastActivityAt` to explicitly ignore unused parameters, normalize `maintainerResolution` to an object, and include `maintainerResolution.resolvedAt` among candidate timestamps while removing direct reliance on treatment timestamp fields.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5c827a94833086e7ebfb855ae215)