### PR TITLE
Fix NC/admin photo parsing to display all uploaded images

### DIFF
--- a/src/lib/storage/images.ts
+++ b/src/lib/storage/images.ts
@@ -1,37 +1,81 @@
 import type { StoredImage } from "@/types/images";
 
+function asStoredImageFromObject(value: unknown): StoredImage | null {
+  if (!value || typeof value !== "object") return null;
+  const maybe = value as Partial<StoredImage>;
+  if (typeof maybe.url !== "string" || !maybe.url.trim()) return null;
+  const provider = maybe.provider === "r2" ? "r2" : "imgbb";
+  return {
+    url: maybe.url.trim(),
+    provider,
+    mime: typeof maybe.mime === "string" ? maybe.mime : undefined,
+    key: typeof maybe.key === "string" ? maybe.key : undefined,
+  };
+}
+
+function parseStringCollection(value: string): unknown[] | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if ((trimmed.startsWith("[") && trimmed.endsWith("]")) || (trimmed.startsWith("{") && trimmed.endsWith("}"))) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      if (Array.isArray(parsed)) return parsed;
+      if (parsed && typeof parsed === "object") return Object.values(parsed as Record<string, unknown>);
+    } catch {
+      return null;
+    }
+  }
+
+  if (trimmed.includes(",")) {
+    return trimmed.split(",").map(part => part.trim()).filter(Boolean);
+  }
+
+  return null;
+}
+
 export function normalizeStoredImage(value: unknown): StoredImage | null {
   if (!value) return null;
 
   if (typeof value === "string") {
+    const collection = parseStringCollection(value);
+    if (collection) {
+      const first = normalizeStoredImages(collection)[0];
+      return first ?? null;
+    }
     const trimmed = value.trim();
     if (!trimmed) return null;
     return { url: trimmed, provider: "imgbb" };
   }
 
-  if (typeof value === "object") {
-    const maybe = value as Partial<StoredImage>;
-    if (typeof maybe.url === "string" && maybe.url.trim()) {
-      const provider = maybe.provider === "r2" ? "r2" : "imgbb";
-      return {
-        url: maybe.url.trim(),
-        provider,
-        mime: typeof maybe.mime === "string" ? maybe.mime : undefined,
-        key: typeof maybe.key === "string" ? maybe.key : undefined,
-      };
-    }
-  }
-
-  return null;
+  return asStoredImageFromObject(value);
 }
 
 export function normalizeStoredImages(value: unknown): StoredImage[] {
   if (!value) return [];
   if (Array.isArray(value)) {
     return value
-      .map(item => normalizeStoredImage(item))
-      .filter((item): item is StoredImage => Boolean(item));
+      .flatMap(item => normalizeStoredImages(item))
+      .filter((item, index, list) => list.findIndex(candidate => candidate.url === item.url && candidate.provider === item.provider) === index);
   }
+
+  if (typeof value === "string") {
+    const collection = parseStringCollection(value);
+    if (collection) {
+      return normalizeStoredImages(collection);
+    }
+  }
+
+  if (value && typeof value === "object") {
+    const single = asStoredImageFromObject(value);
+    if (single) return [single];
+
+    const objectValues = Object.values(value as Record<string, unknown>);
+    if (objectValues.length > 0) {
+      return normalizeStoredImages(objectValues);
+    }
+  }
+
   const single = normalizeStoredImage(value);
   return single ? [single] : [];
 }
@@ -42,4 +86,3 @@ export function mapStringsToStoredImages(urls: string[]): StoredImage[] {
     .filter(Boolean)
     .map(url => ({ url, provider: "imgbb" as const }));
 }
-

--- a/src/lib/storage/images.ts
+++ b/src/lib/storage/images.ts
@@ -17,6 +17,10 @@ function parseStringCollection(value: string): unknown[] | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
 
+  if (trimmed.startsWith("data:")) {
+    return null;
+  }
+
   if ((trimmed.startsWith("[") && trimmed.endsWith("]")) || (trimmed.startsWith("{") && trimmed.endsWith("}"))) {
     try {
       const parsed = JSON.parse(trimmed) as unknown;
@@ -28,7 +32,11 @@ function parseStringCollection(value: string): unknown[] | null {
   }
 
   if (trimmed.includes(",")) {
-    return trimmed.split(",").map(part => part.trim()).filter(Boolean);
+    const parts = trimmed.split(",").map(part => part.trim()).filter(Boolean);
+    const looksLikeUrlList = parts.length > 1 && parts.every(part => /^https?:\/\//i.test(part));
+    if (looksLikeUrlList) {
+      return parts;
+    }
   }
 
   return null;


### PR DESCRIPTION
### Motivation
- Admin views (`/admin/inspecoes`, `/admin/nc`) were showing only one photo even when three images existed in Cloudflare R2 because stored `fotos/photoUrls` can be persisted in varied legacy formats and the old parser treated many variants as a single URL. 
- The goal is to reliably recover all stored images for inspection items and NCs regardless of whether the Firestore field is an array, object map, JSON string, or comma-separated string.

### Description
- Rewrote `src/lib/storage/images.ts` to add a robust parser that recognizes arrays, object maps, JSON stringified collections, and comma-separated strings via `parseStringCollection` and `asStoredImageFromObject` helper functions. 
- Made `normalizeStoredImages` recursive so nested collections are fully expanded and supported non-array object shapes by traversing `Object.values` when needed. 
- Added deduplication logic (by `provider + url`) to avoid duplicate thumbnails and standardized provider detection between `r2` and `imgbb`.
- Updated `normalizeStoredImage` to route string collections to the recursive normalizer so legacy stringified collections return all contained images instead of a single entry.

### Testing
- Ran `npm run -s lint` which completed successfully with one unrelated pre-existing warning in `next.config.ts`. 
- Ran the single test `npm run -s test -- tests/non-conformity-priority.test.ts` which exited non-zero in this environment and did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ee2331908330b27208ab9bc7ee9a)