### PR TITLE
Corrige persistência de múltiplas fotos em inspeções

### DIFF
--- a/src/app/inspecao/[tag]/page.tsx
+++ b/src/app/inspecao/[tag]/page.tsx
@@ -1068,13 +1068,13 @@ export default function InspectionPage() {
   }, []);
 
   const queueBackgroundUploads = useCallback(
-    (inspectionId: string, uploads: PendingUpload[]) => {
+    async (inspectionId: string, uploads: PendingUpload[]) => {
       if (!inspectionId || uploads.length === 0) return;
 
       uploadQueueRef.current = uploads.reduce<Promise<void>>((chain, upload) => {
         return chain.then(async () => {
           try {
-            await fetch(`/api/inspecoes/${encodeURIComponent(inspectionId)}/fotos`, {
+            const response = await fetch(`/api/inspecoes/${encodeURIComponent(inspectionId)}/fotos`, {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({
@@ -1083,11 +1083,18 @@ export default function InspectionPage() {
                 fileName: upload.fileName ?? undefined,
               }),
             });
+            if (!response.ok) {
+              const payload = await response.json().catch(() => null);
+              throw new Error(typeof payload?.error === "string" ? payload.error : "Falha no upload das fotos.");
+            }
           } catch (err) {
             console.error("[inspection-upload]", err);
+            throw err;
           }
         });
       }, uploadQueueRef.current);
+
+      await uploadQueueRef.current;
     },
     []
   );
@@ -1277,7 +1284,7 @@ export default function InspectionPage() {
           params.set("inspecaoId", inspectionId);
         }
         if (inspectionId) {
-          queueBackgroundUploads(inspectionId, pendingUploads);
+          await queueBackgroundUploads(inspectionId, pendingUploads);
         }
         router.replace(`/home?${params.toString()}`);
       } catch (err: unknown) {


### PR DESCRIPTION
### Motivation
- Uploads de fotos eram disparados em background e o redirecionamento interrompia requisições pendentes, resultando na persistência de apenas uma foto por item.
- É necessário detectar falhas de upload para evitar sucesso silencioso e perda de evidências fotográficas.

### Description
- Altera `queueBackgroundUploads` para ser `async` e aguardar a execução sequencial das requisições de upload retornando uma `Promise` que é resolvida quando todos os uploads terminam.
- Passa a validar `response.ok` em cada `fetch` para o endpoint `POST /api/inspecoes/{id}/fotos` e lança erro com a mensagem retornada pela API quando houver falha.
- No fluxo de submissão (`submitInspection`) agora é feito `await queueBackgroundUploads(inspectionId, pendingUploads)` antes de chamar `router.replace(...)` para garantir que todos os uploads sejam concluídos.

### Testing
- Executado `npm run -s lint`, que passou (apenas 1 warning pré-existente em `next.config.ts`) and não foram introduzidos erros de lint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21595bf548330984779213acc2952)