### PR TITLE
Fix Firestore undefined machine fields in programação upload API

### DIFF
--- a/src/app/api/programacao/upload/route.ts
+++ b/src/app/api/programacao/upload/route.ts
@@ -491,8 +491,8 @@ export async function POST(req: NextRequest) {
         machine: {
           tag,
           nome: descricao,
-          machineId: machineRecord?.id,
-          templateId: machineRecord?.templateId,
+          machineId: machineRecord?.id ?? null,
+          templateId: machineRecord?.templateId ?? null,
           codTarefaConfigurado: configuredCodTarefa || null,
           machineNotFound: !machineRecord,
         },


### PR DESCRIPTION
### Motivation
- Prevenir o erro do Firestore `Cannot use "undefined" as a Firestore value` e o HTTP 500 no endpoint `POST /api/programacao/upload` durante importação de Excel, causado por campos `machine.machineId` e `machine.templateId` possivelmente ficando `undefined`.

### Description
- Normalizar os campos `machine.machineId` e `machine.templateId` para `null` quando `machineRecord` não existe, aplicando `?? null` em `src/app/api/programacao/upload/route.ts`.

### Testing
- Rodei o verificador de tipos com `npm run typecheck` e a checagem completou com sucesso sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10402efdc48330b1426460bc441fc8)