### PR TITLE
Filtro de ordenação por data de vencimento na tela /admin/nc

### DIFF
--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -28,7 +28,7 @@ import type {
   NonConformityStatus,
   StoredImage,
 } from "@/types";
-import { resolveIssueLastActivityAt, sortByLastActivityDesc } from "@/lib/non-conformity-priority";
+import { resolveIssueLastActivityAt, sortByDueDateAsc, sortByLastActivityDesc } from "@/lib/non-conformity-priority";
 import { normalizeStoredImages } from "@/lib/storage/images";
 
 interface MachineOption {
@@ -259,6 +259,7 @@ export default function AdminNonConformitiesPage() {
   const [machineFilter, setMachineFilter] = useState("");
   const [maintainerFilter, setMaintainerFilter] = useState("");
   const [statusFilter, setStatusFilter] = useState("open");
+  const [dueDateFilter, setDueDateFilter] = useState("default");
   const [savingId, setSavingId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Record<string, FeedbackState>>({});
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
@@ -545,7 +546,7 @@ export default function AdminNonConformitiesPage() {
 
   const filteredItems = useMemo(() => {
     const machineSearch = machineFilter.trim().toLowerCase();
-    return items.filter(item => {
+    const visibleItems = items.filter(item => {
       if (machineSearch) {
         const machineLabel = item.machineLabel.toLowerCase();
         const machineTag = (item.machineTag ?? "").toLowerCase();
@@ -575,7 +576,13 @@ export default function AdminNonConformitiesPage() {
       }
       return item.status === statusFilter;
     });
-  }, [items, machineFilter, maintainerFilter, statusFilter]);
+
+    if (dueDateFilter === "oldest_first") {
+      return sortByDueDateAsc(visibleItems);
+    }
+
+    return visibleItems;
+  }, [items, machineFilter, maintainerFilter, statusFilter, dueDateFilter]);
 
   const handleUpdateItem = useCallback((id: string, updates: Partial<NonConformityItem>) => {
     setItems(prev => prev.map(item => (item.id === id ? { ...item, ...updates } : item)));
@@ -811,7 +818,7 @@ export default function AdminNonConformitiesPage() {
         <CardHeader className="pb-4">
           <CardTitle className="text-base text-[var(--text)]">Filtros</CardTitle>
         </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-3">
+        <CardContent className="grid gap-4 md:grid-cols-4">
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Máquina</span>
             <Input
@@ -847,6 +854,13 @@ export default function AdminNonConformitiesPage() {
               <option value="open">Abertas</option>
               <option value="resolved">Resolvidas</option>
               <option value="maintainer_resolved">Realizado pelo mantenedor</option>
+            </Select>
+          </label>
+          <label className="space-y-1 text-sm">
+            <span className="text-[var(--muted)]">Data de vencimento</span>
+            <Select value={dueDateFilter} onChange={event => setDueDateFilter(event.target.value)}>
+              <option value="default">Padrão: atividade mais recente</option>
+              <option value="oldest_first">Mais antigo para mais novo</option>
             </Select>
           </label>
         </CardContent>

--- a/src/lib/non-conformity-priority.ts
+++ b/src/lib/non-conformity-priority.ts
@@ -87,3 +87,13 @@ export function sortByLastActivityDesc<T extends { updatedAt: string | null; che
     return normalizedB - normalizedA;
   });
 }
+
+export function sortByDueDateAsc<T extends { dueDateIso: string | null; dueDate: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => {
+    const aTs = Date.parse(a.dueDateIso ?? a.dueDate);
+    const bTs = Date.parse(b.dueDateIso ?? b.dueDate);
+    const normalizedA = Number.isNaN(aTs) ? Number.POSITIVE_INFINITY : aTs;
+    const normalizedB = Number.isNaN(bTs) ? Number.POSITIVE_INFINITY : bTs;
+    return normalizedA - normalizedB;
+  });
+}

--- a/tests/non-conformity-priority.test.ts
+++ b/tests/non-conformity-priority.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   buildIssueRecurrenceUpdates,
   resolveIssueLastActivityAt,
+  sortByDueDateAsc,
   sortByLastActivityDesc,
 } from "../src/lib/non-conformity-priority.ts";
 
@@ -56,5 +57,18 @@ test("tratativa reincidente sobe para o topo da lista", () => {
   assert.deepEqual(
     sorted.map(item => item.id),
     ["new", "fallback", "old"]
+  );
+});
+
+test("ordena NCs por vencimento do mais antigo para o mais novo", () => {
+  const sorted = sortByDueDateAsc([
+    { id: "without-date", dueDate: "", dueDateIso: null },
+    { id: "newer", dueDate: "2026-04-10", dueDateIso: "2026-04-10T00:00:00.000Z" },
+    { id: "older", dueDate: "2026-03-10", dueDateIso: "2026-03-10T00:00:00.000Z" },
+  ]);
+
+  assert.deepEqual(
+    sorted.map(item => item.id),
+    ["older", "newer", "without-date"]
   );
 });


### PR DESCRIPTION
### Motivation
- Permitir ordenação das não conformidades por data de vencimento (do mais antigo para o mais novo) além do ordenamento padrão por atividade mais recente, conforme solicitado para a tela `/admin/nc`.

### Description
- Adiciona um novo seletor de filtro "Data de vencimento" na UI de filtros em `src/app/admin/nc/page.tsx` com opções `Padrão: atividade mais recente` e `Mais antigo para mais novo` e expande o layout de filtros para comportar o novo controle.
- Introduz o utilitário `sortByDueDateAsc` em `src/lib/non-conformity-priority.ts` que ordena por `dueDateIso`/`dueDate` crescente e coloca itens sem data válida ao final.
- Integra a nova ordenação ao pipeline de filtros: os itens são filtrados por máquina/mantenedor/status e, quando selecionado, ordenados por vencimento antes de renderizar.
- Adiciona um teste em `tests/non-conformity-priority.test.ts` que valida a ordenação por vencimento (mais antigo → mais novo).

### Testing
- Executado `npm run typecheck` e o `tsc --noEmit` passou com sucesso.
- Executado `npm run lint` e o `eslint` passou (existem 2 avisos preexistentes em arquivos não modificados).
- Tentativa de rodar os testes TypeScript com `node --test` falhou pelo ambiente não carregar `.ts` sem loader, e `npx tsx --test` não pôde ser executado devido a bloqueio do registry (403), portanto o novo teste unitário foi adicionado mas não pôde ser executado no ambiente CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b01057880832893dd92709009a5bc)