### PR TITLE
Fix Firestore image normalization

### DIFF
--- a/src/lib/storage/images.ts
+++ b/src/lib/storage/images.ts
@@ -5,12 +5,19 @@ function asStoredImageFromObject(value: unknown): StoredImage | null {
   const maybe = value as Partial<StoredImage>;
   if (typeof maybe.url !== "string" || !maybe.url.trim()) return null;
   const provider = maybe.provider === "r2" ? "r2" : "imgbb";
-  return {
+  const image: StoredImage = {
     url: maybe.url.trim(),
     provider,
-    mime: typeof maybe.mime === "string" ? maybe.mime : undefined,
-    key: typeof maybe.key === "string" ? maybe.key : undefined,
   };
+
+  if (typeof maybe.mime === "string" && maybe.mime.trim()) {
+    image.mime = maybe.mime.trim();
+  }
+  if (typeof maybe.key === "string" && maybe.key.trim()) {
+    image.key = maybe.key.trim();
+  }
+
+  return image;
 }
 
 function parseStringCollection(value: string): unknown[] | null {


### PR DESCRIPTION
### Motivation
- A atualização da inspeção falhava com erro do Firestore porque o payload continha campos opcionais com valor `undefined` dentro de `fotos.*.key`, o que o Firestore rejeita. 
- Ajustar a normalização de imagens para omitir campos vazios e evitar enviar `undefined` em documentos.

### Description
- Altera `src/lib/storage/images.ts` para construir um `StoredImage` mínimo com `url` e `provider` e só adicionar `mime`/`key` quando forem strings não vazias. 
- Aplica `trim()` em `mime` e `key` antes de persistir para evitar salvar valores em branco. 
- Isso garante que `normalizeStoredImages` não retorne objetos com propriedades opcionais definidas como `undefined` dentro do payload enviado ao Firestore.

### Testing
- Executado `npm run typecheck` com sucesso. 
- Executado `npm run lint`, que passou mantendo 2 avisos preexistentes. 
- Tentativa de rodar os testes com `node --test tests/non-conformity-priority.test.ts` falhou pois o Node não carrega arquivos `.ts` diretamente sem um loader, portanto não houve execução direta dos testes unitários em TypeScript no ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3052445ccc8328ae4f3f9cdf2200e5)