### PR TITLE
Improve maintainer filtering and reconcile issue statuses before inspection

### DIFF
--- a/src/app/admin/checklists/page.tsx
+++ b/src/app/admin/checklists/page.tsx
@@ -113,6 +113,30 @@ function ensureNumber(value: unknown) {
   return typeof value === "number" ? value : null;
 }
 
+function normalizeTextKey(value: string | null | undefined) {
+  return value?.trim().toLowerCase() ?? null;
+}
+
+function buildMaintainerFilterKeys(maintainer: MaintainerOption | null | undefined) {
+  if (!maintainer) return new Set<string>();
+  return new Set(
+    [maintainer.id, maintainer.matricula, normalizeTextKey(maintainer.nome)]
+      .map(value => value?.trim())
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+function rowMatchesMaintainer(row: ChecklistRow, selectedMaintainer: MaintainerOption | null | undefined) {
+  const selectedKeys = buildMaintainerFilterKeys(selectedMaintainer);
+  if (selectedKeys.size === 0) return false;
+
+  const rowKeys = [row.maintainerId, row.maintainerMatricula, normalizeTextKey(row.maintainerNome)]
+    .map(value => value?.trim())
+    .filter((value): value is string => Boolean(value));
+
+  return rowKeys.some(key => selectedKeys.has(key));
+}
+
 function computeNcCount(data: Record<string, unknown>): number {
   const qtdNc = ensureNumber(data.qtdNC);
   if (typeof qtdNc === "number" && !Number.isNaN(qtdNc)) {
@@ -250,7 +274,7 @@ export default function AdminChecklistsPage() {
     setError(null);
     try {
       const snap = await getDocs(query(inspectionsCol, orderBy("createdAt", "desc")));
-      const allRows: ChecklistRow[] = snap.docs.slice(0, MAX_RESULTS).map(docSnap => {
+      const allRows: ChecklistRow[] = snap.docs.map(docSnap => {
         const data = docSnap.data() ?? {};
         const machine = (data.machine ?? {}) as Record<string, unknown>;
         const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
@@ -288,6 +312,8 @@ export default function AdminChecklistsPage() {
       });
 
       const machineQuery = filter.machineTag?.trim().toLowerCase();
+      const selectedMaintainer =
+        filter.maintainerId === "all" ? null : maintainerById.get(filter.maintainerId) ?? null;
 
       const filtered = allRows.filter(row => {
         if (machineQuery) {
@@ -298,7 +324,7 @@ export default function AdminChecklistsPage() {
             return false;
           }
         }
-        if (filter.maintainerId !== "all" && row.maintainerId !== filter.maintainerId) {
+        if (filter.maintainerId !== "all" && !rowMatchesMaintainer(row, selectedMaintainer)) {
           return false;
         }
         if (filter.templateId !== "all" && row.templateId !== filter.templateId) {
@@ -334,7 +360,7 @@ export default function AdminChecklistsPage() {
         return true;
       });
 
-      setRows(filtered);
+      setRows(filter.maintainerId === "all" ? filtered.slice(0, MAX_RESULTS) : filtered);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Erro ao carregar checklists";
       setError(message);

--- a/src/app/api/inspecao/context/route.ts
+++ b/src/app/api/inspecao/context/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import type { QueryDocumentSnapshot, DocumentData } from "firebase-admin/firestore";
 import { adminDb } from "@/lib/firebase-admin";
 import { findMachineByTag } from "@/lib/db/machines";
 import { requireMaint } from "@/lib/guards";
@@ -7,6 +8,77 @@ import { sanitizeIsoHeaderConfig } from "@/lib/iso-header-config";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+function isTreatmentResolved(value: unknown) {
+  if (!value || typeof value !== "object") return false;
+  const status = String((value as Record<string, unknown>).status ?? "").trim().toLowerCase();
+  return status === "resolved" || status === "resolvida" || status === "concluida" || status === "concluída" || status === "closed";
+}
+
+function hasMaintainerResolution(value: unknown) {
+  if (!value || typeof value !== "object") return false;
+  const resolution = value as Record<string, unknown>;
+  return typeof resolution.resolvedAt === "string" && resolution.resolvedAt.trim().length > 0;
+}
+
+async function findSourceTreatment(issueData: Record<string, unknown>) {
+  const inspectionId = typeof issueData.abertaEmInspecaoId === "string" ? issueData.abertaEmInspecaoId.trim() : "";
+  const templateItemId = typeof issueData.templateItemId === "string" ? issueData.templateItemId.trim() : "";
+  if (!inspectionId || !templateItemId) return null;
+
+  const inspectionSnap = await adminDb.collection("inspecoes").doc(inspectionId).get();
+  const treatments = Array.isArray(inspectionSnap.data()?.nonConformityTreatments)
+    ? (inspectionSnap.data()?.nonConformityTreatments as Array<Record<string, unknown>>)
+    : [];
+
+  return treatments.find(treatment => treatment.questionId === templateItemId) ?? null;
+}
+
+async function reconcileIssueBeforeInspection(issueDoc: QueryDocumentSnapshot<DocumentData>, nowIso: string) {
+  const data = issueDoc.data() ?? {};
+  const rawStatus = String(data.status ?? "aberta").trim().toLowerCase();
+  if (rawStatus === "resolvida") return "resolvida";
+
+  const sourceTreatment = isTreatmentResolved(data.pcmTreatment) ? null : await findSourceTreatment(data);
+  const pcmMarkedResolved = isTreatmentResolved(data.pcmTreatment) || isTreatmentResolved(sourceTreatment);
+  const maintainerAlreadyConfirmed = hasMaintainerResolution(data.maintainerResolution);
+
+  if (pcmMarkedResolved && maintainerAlreadyConfirmed) {
+    await issueDoc.ref.update({
+      status: "resolvida",
+      resolvedAt: typeof data.resolvedAt === "string" ? data.resolvedAt : nowIso,
+      reconciledAt: nowIso,
+      reconciledReason: "pcm_treatment_and_maintainer_resolution",
+      updatedAt: nowIso,
+    });
+    return "resolvida";
+  }
+
+  if (rawStatus === "aberta" && pcmMarkedResolved) {
+    await issueDoc.ref.update({
+      status: "concluida",
+      concluidaEm: typeof data.concluidaEm === "string" ? data.concluidaEm : nowIso,
+      concluidaPorTratativa: true,
+      reconciledAt: nowIso,
+      reconciledReason: "pcm_treatment_resolved",
+      updatedAt: nowIso,
+    });
+    return "concluida";
+  }
+
+  if (rawStatus === "concluida" && maintainerAlreadyConfirmed) {
+    await issueDoc.ref.update({
+      status: "resolvida",
+      resolvedAt: typeof data.resolvedAt === "string" ? data.resolvedAt : nowIso,
+      reconciledAt: nowIso,
+      reconciledReason: "concluded_with_maintainer_resolution",
+      updatedAt: nowIso,
+    });
+    return "resolvida";
+  }
+
+  return rawStatus === "concluida" ? "concluida" : "aberta";
+}
 
 function extractMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) {
@@ -73,27 +145,37 @@ export async function GET(req: NextRequest) {
       .where("status", "in", ["aberta", "concluida"])
       .get();
 
-    const openIssues = issuesSnap.docs.map(doc => {
-      const data = doc.data() ?? {};
-      const rawResolution = data.maintainerResolution ?? null;
-      const maintainerResolution = rawResolution && typeof rawResolution === "object"
-        ? {
-            resolvedAt: rawResolution.resolvedAt ?? null,
-            description: rawResolution.description ?? null,
-            resolvedByName: rawResolution.resolvedByName ?? null,
-          }
-        : null;
-      return {
-        id: doc.id,
-        templateItemId: data.templateItemId ?? null,
-        descricao: data.descricao ?? null,
-        osNumero: data.osNumero ?? null,
-        fotos: normalizeStoredImages(data.fotos ?? []),
-        createdAt: data.createdAt ?? null,
-        status: data.status === "concluida" ? "concluida" : "aberta",
-        maintainerResolution,
-      };
-    });
+    const nowIso = new Date().toISOString();
+    const reconciledIssues = await Promise.all(
+      issuesSnap.docs.map(async doc => ({
+        doc,
+        status: await reconcileIssueBeforeInspection(doc, nowIso),
+      })),
+    );
+
+    const openIssues = reconciledIssues
+      .filter(issue => issue.status !== "resolvida")
+      .map(({ doc, status }) => {
+        const data = doc.data() ?? {};
+        const rawResolution = data.maintainerResolution ?? null;
+        const maintainerResolution = rawResolution && typeof rawResolution === "object"
+          ? {
+              resolvedAt: rawResolution.resolvedAt ?? null,
+              description: rawResolution.description ?? null,
+              resolvedByName: rawResolution.resolvedByName ?? null,
+            }
+          : null;
+        return {
+          id: doc.id,
+          templateItemId: data.templateItemId ?? null,
+          descricao: data.descricao ?? null,
+          osNumero: data.osNumero ?? null,
+          fotos: normalizeStoredImages(data.fotos ?? []),
+          createdAt: data.createdAt ?? null,
+          status: status === "concluida" ? "concluida" : "aberta",
+          maintainerResolution,
+        };
+      });
 
     return NextResponse.json({
       maintainer: {


### PR DESCRIPTION
### Motivation
- Make maintainer filtering in the admin checklists page more robust by allowing matches by id, matricula or normalized name, and avoid prematurely truncating results.
- Ensure issues returned by the inspection context API reflect reconciled status by reconciling PCM treatments and maintainer confirmations before responding.

### Description
- Added `normalizeTextKey`, `buildMaintainerFilterKeys`, and `rowMatchesMaintainer` to `src/app/admin/checklists/page.tsx` to match maintainers by `id`, `matricula`, or normalized `nome` and used this in the rows filtering logic. 
- Stopped slicing `snap.docs` early and instead apply the `MAX_RESULTS` truncation only after filtering so maintainer-specific queries return relevant rows. 
- Introduced `isTreatmentResolved`, `hasMaintainerResolution`, `findSourceTreatment`, and `reconcileIssueBeforeInspection` in `src/app/api/inspecao/context/route.ts` to determine and persist reconciled issue states based on PCM treatments and maintainer resolutions. 
- Updated the GET handler in `src/app/api/inspecao/context/route.ts` to reconcile issue documents before building the `openIssues` response and to set appropriate `status`, timestamps and reconciliation metadata on the server side.

### Testing
- Ran TypeScript compile (`tsc --noEmit`) to ensure types are consistent and the build passes. 
- Ran the existing automated test suite (`yarn test`) and it completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a313a2f6d7c8328b7b41350c6870185)