### PR TITLE
Detect CSV delimiter (comma/semicolon/tab) during programação upload

### DIFF
--- a/src/app/api/programacao/upload/route.ts
+++ b/src/app/api/programacao/upload/route.ts
@@ -282,7 +282,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const buffer = Buffer.from(await file.arrayBuffer());
-    const rows = parseCsv(buffer, { delimiter: ",", skipEmptyLines: true }) as RawRow[];
+    const rows = parseCsv(buffer, { skipEmptyLines: true }) as RawRow[];
 
     if (!rows.length) {
       return NextResponse.json({ error: "EMPTY_CSV" }, { status: 400 });

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -7,11 +7,9 @@ export interface ParseCsvOptions {
   skipEmptyLines?: boolean;
 }
 
-export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}): CsvRow[] {
-  const delimiter = options.delimiter ?? ",";
-  const skipEmptyLines = options.skipEmptyLines ?? true;
+const CANDIDATE_DELIMITERS = [",", ";", "\t"] as const;
 
-  const text = (typeof content === "string" ? content : content.toString("utf-8")).replace(/^\ufeff/, "");
+function splitCsvRows(text: string, delimiter: string, skipEmptyLines: boolean): string[][] {
   const rows: string[][] = [];
   let currentField = "";
   let currentRow: string[] = [];
@@ -68,6 +66,35 @@ export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}
   if (currentRow.length > 1 || currentRow[0]?.trim()) {
     pushRow();
   }
+
+  return rows;
+}
+
+function scoreRows(rows: string[][]) {
+  if (!rows.length) return 0;
+  const [header, ...dataRows] = rows;
+  const headerColumns = header.length;
+  const comparableRows = dataRows.slice(0, 25);
+  const matchingRows = comparableRows.filter(row => row.length === headerColumns).length;
+  const populatedHeaders = header.filter(column => column.trim().length > 0).length;
+
+  return headerColumns * 100 + populatedHeaders * 10 + matchingRows;
+}
+
+function detectDelimiter(text: string, skipEmptyLines: boolean) {
+  return CANDIDATE_DELIMITERS.map(delimiter => ({
+    delimiter,
+    rows: splitCsvRows(text, delimiter, skipEmptyLines),
+  })).sort((a, b) => scoreRows(b.rows) - scoreRows(a.rows))[0]!;
+}
+
+export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}): CsvRow[] {
+  const skipEmptyLines = options.skipEmptyLines ?? true;
+
+  const text = (typeof content === "string" ? content : content.toString("utf-8")).replace(/^\ufeff/, "");
+  const rows = options.delimiter
+    ? splitCsvRows(text, options.delimiter, skipEmptyLines)
+    : detectDelimiter(text, skipEmptyLines).rows;
 
   if (!rows.length) {
     return [];


### PR DESCRIPTION
### Motivation

- Spreadsheet apps in some locales save CSVs with `;` or `\t` as delimiters which broke imports when the server forced `,` as the separator.
- The change aims to make CSV imports resilient to common delimiter changes without requiring users to re-save files with a specific separator.

### Description

- Reworked the CSV parser by extracting row-splitting into `splitCsvRows` and adding `detectDelimiter` which scores candidate delimiters `,`, `;`, and `\t` and picks the best match. 
- `parseCsv` now uses the detected delimiter when `options.delimiter` is not provided while preserving explicit delimiter support and BOM trimming. 
- Updated the programação upload handler to stop forcing `delimiter: ","` and instead call `parseCsv(buffer, { skipEmptyLines: true })` so uploaded files are parsed with the correct separator. 

### Testing

- Ran `npm run typecheck` which completed successfully. 
- Ran `npm run lint` which completed and reported 2 existing unrelated warnings but no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42c22a6fd8832895d89711cd8ce65a)