### PR TITLE
Improve CSV parsing: automatic delimiter detection and robust row splitting

### DIFF
--- a/src/app/api/programacao/upload/route.ts
+++ b/src/app/api/programacao/upload/route.ts
@@ -282,7 +282,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const buffer = Buffer.from(await file.arrayBuffer());
-    const rows = parseCsv(buffer, { delimiter: ",", skipEmptyLines: true }) as RawRow[];
+    const rows = parseCsv(buffer, { skipEmptyLines: true }) as RawRow[];
 
     if (!rows.length) {
       return NextResponse.json({ error: "EMPTY_CSV" }, { status: 400 });

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -7,11 +7,9 @@ export interface ParseCsvOptions {
   skipEmptyLines?: boolean;
 }
 
-export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}): CsvRow[] {
-  const delimiter = options.delimiter ?? ",";
-  const skipEmptyLines = options.skipEmptyLines ?? true;
+const CANDIDATE_DELIMITERS = [",", ";", "\t"] as const;
 
-  const text = (typeof content === "string" ? content : content.toString("utf-8")).replace(/^\ufeff/, "");
+function splitCsvRows(text: string, delimiter: string, skipEmptyLines: boolean): string[][] {
   const rows: string[][] = [];
   let currentField = "";
   let currentRow: string[] = [];
@@ -69,6 +67,36 @@ export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}
     pushRow();
   }
 
+  return rows;
+}
+
+function scoreRows(rows: string[][]) {
+  if (!rows.length) return 0;
+  const [header, ...dataRows] = rows;
+  const headerColumns = header.length;
+  const comparableRows = dataRows.slice(0, 25);
+  const matchingRows = comparableRows.filter(row => row.length === headerColumns).length;
+  const populatedHeaders = header.filter(column => column.trim().length > 0).length;
+
+  return headerColumns * 100 + populatedHeaders * 10 + matchingRows;
+}
+
+function detectDelimiter(text: string, skipEmptyLines: boolean) {
+  return CANDIDATE_DELIMITERS.map(delimiter => ({
+    delimiter,
+    rows: splitCsvRows(text, delimiter, skipEmptyLines),
+  })).sort((a, b) => scoreRows(b.rows) - scoreRows(a.rows))[0]!;
+}
+
+export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}): CsvRow[] {
+  const skipEmptyLines = options.skipEmptyLines ?? true;
+
+  const text = (typeof content === "string" ? content : content.toString("utf-8")).replace(/^\ufeff/, "");
+  const parsed = options.delimiter
+    ? { delimiter: options.delimiter, rows: splitCsvRows(text, options.delimiter, skipEmptyLines) }
+    : detectDelimiter(text, skipEmptyLines);
+  const { delimiter, rows } = parsed;
+
   if (!rows.length) {
     return [];
   }
@@ -78,9 +106,12 @@ export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}
   const records: CsvRow[] = [];
 
   for (const dataRow of dataRows) {
+    const normalizedRow = dataRow.length === 1 && headers.length > 1 && dataRow[0]?.includes(delimiter)
+      ? splitCsvRows(dataRow[0], delimiter, false)[0] ?? dataRow
+      : dataRow;
     const record: CsvRow = {};
     headers.forEach((column, index) => {
-      record[column] = (dataRow[index] ?? "").trim();
+      record[column] = (normalizedRow[index] ?? "").trim();
     });
     records.push(record);
   }


### PR DESCRIPTION
### Motivation

- Make CSV ingestion more resilient by supporting common delimiters (comma/semicolon/tab) without requiring callers to specify one.  
- Handle malformed rows where a single field contains the delimiter so column alignment is preserved.  
- Simplify the upload handler by removing the hardcoded delimiter option and relying on the parser's detection.

### Description

- Added `CANDIDATE_DELIMITERS` and implemented `splitCsvRows`, `scoreRows`, and `detectDelimiter` helpers to try multiple delimiters and choose the best fit.  
- Refactored `parseCsv` to auto-detect delimiter by default while still honoring an explicit `delimiter` option, and to normalize rows where a single field contains the delimiter.  
- Updated the upload endpoint call to `parseCsv` to remove the explicit `delimiter` parameter so detection is used.  
- Minor cleanup and UTF-8 BOM trimming preserved when converting buffers to text.

### Testing

- Ran the test suite with `npm test` and all unit tests passed.  
- Ran linting with `npm run lint` and no lint errors were reported.  
- Verified parser behavior against sample CSV files with `,`, `;`, and `\t` delimiters in automated unit tests used by the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42c22a6fd8832895d89711cd8ce65a)