### PR TITLE
Add pagination and filtering improvements; robust CSV parsing; normalize OS numbers across NC flows

### DIFF
--- a/src/app/admin/checklists/page.tsx
+++ b/src/app/admin/checklists/page.tsx
@@ -1,14 +1,18 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import {
   collection,
   deleteDoc,
   doc,
   getDocs,
+  limit,
   orderBy,
   query,
+  startAfter,
+  type DocumentData,
+  type QueryDocumentSnapshot,
 } from "firebase/firestore";
 
 import { Button, buttonStyles } from "@/components/ui/button";
@@ -153,7 +157,8 @@ function computeNcCount(data: Record<string, unknown>): number {
   return itensRaw.filter(item => String(item.resultado ?? item.response ?? "c").toLowerCase() === "nc").length;
 }
 
-const MAX_RESULTS = 1000;
+const PAGE_SIZE = 20;
+type InspectionCursor = QueryDocumentSnapshot<DocumentData>;
 
 export default function AdminChecklistsPage() {
   const [machines, setMachines] = useState<MachineOption[]>([]);
@@ -168,6 +173,9 @@ export default function AdminChecklistsPage() {
   });
   const [loadingLookups, setLoadingLookups] = useState(true);
   const [loadingRows, setLoadingRows] = useState(true);
+  const [loadingMoreRows, setLoadingMoreRows] = useState(false);
+  const lastInspectionCursorRef = useRef<InspectionCursor | null>(null);
+  const [hasMoreRows, setHasMoreRows] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [periodExporting, setPeriodExporting] = useState(false);
   const [periodDeleting, setPeriodDeleting] = useState(false);
@@ -269,109 +277,131 @@ export default function AdminChecklistsPage() {
   const maintainerById = useMemo(() => new Map(maintainers.map(item => [item.id, item])), [maintainers]);
   const templateById = useMemo(() => new Map(templates.map(item => [item.id, item])), [templates]);
 
-  const fetchRows = useCallback(async () => {
-    setLoadingRows(true);
+  const mapInspectionDoc = useCallback((docSnap: InspectionCursor) => {
+    const data = docSnap.data() ?? {};
+    const machine = (data.machine ?? {}) as Record<string, unknown>;
+    const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
+    const template = (data.template ?? {}) as Record<string, unknown>;
+
+    const machineId = ensureString(machine.machineId) ?? ensureString(machine.id);
+    const machineFallback = machineId ? machineById.get(machineId) : null;
+    const maintainerId = ensureString(maintainer.maintId) ?? ensureString(maintainer.id);
+    const maintainerFallback = maintainerId ? maintainerById.get(maintainerId) : null;
+    const templateId = ensureString(template.id);
+    const templateFallback = templateId ? templateById.get(templateId) : null;
+
+    const ncCount = computeNcCount(data);
+
+    return {
+      id: docSnap.id,
+      createdAt: ensureString(data.createdAt) ?? ensureString(data.finalizadaEm) ?? ensureString(data.iniciadaEm),
+      machineId: machineId,
+      machineNome: ensureString(machine.nome) ?? machineFallback?.nome ?? null,
+      machineTag: ensureString(machine.tag) ?? machineFallback?.tag ?? null,
+      machineSetor: ensureString(machine.setor) ?? machineFallback?.setor ?? null,
+      maintainerId,
+      maintainerNome: ensureString(maintainer.nome) ?? maintainerFallback?.nome ?? null,
+      maintainerMatricula:
+        ensureString(maintainer.matricula) ?? maintainerFallback?.matricula ?? null,
+      templateId,
+      templateNome:
+        ensureString(template.nome) ?? ensureString(template.title) ?? templateFallback?.nome ?? null,
+      templateVersao:
+        ensureString(template.versao) ?? ensureString(template.version) ?? templateFallback?.versao ?? null,
+      osNumero: ensureString(data.osNumero),
+      ncCount,
+      hasNc: ncCount > 0,
+    } satisfies ChecklistRow;
+  }, [machineById, maintainerById, templateById]);
+
+  const applyCurrentFilters = useCallback((items: ChecklistRow[]) => {
+    const machineQuery = filter.machineTag?.trim().toLowerCase();
+    const selectedMaintainer =
+      filter.maintainerId === "all" ? null : maintainerById.get(filter.maintainerId) ?? null;
+
+    return items.filter(row => {
+      if (machineQuery) {
+        const tag = row.machineTag?.toLowerCase() ?? "";
+        const name = row.machineNome?.toLowerCase() ?? "";
+        const setor = row.machineSetor?.toLowerCase() ?? "";
+        if (!tag.includes(machineQuery) && !name.includes(machineQuery) && !setor.includes(machineQuery)) {
+          return false;
+        }
+      }
+      if (filter.maintainerId !== "all" && !rowMatchesMaintainer(row, selectedMaintainer)) {
+        return false;
+      }
+      if (filter.templateId !== "all" && row.templateId !== filter.templateId) {
+        return false;
+      }
+      if (filter.hasNc === "yes" && !row.hasNc) {
+        return false;
+      }
+      if (filter.hasNc === "no" && row.hasNc) {
+        return false;
+      }
+      if (filter.matricula?.trim()) {
+        const wanted = filter.matricula.trim().toLowerCase();
+        const matricula = row.maintainerMatricula?.toLowerCase() ?? "";
+        if (!matricula.includes(wanted)) {
+          return false;
+        }
+      }
+      if (filter.from) {
+        const fromDate = new Date(`${filter.from}T00:00:00`);
+        const createdAt = normalizeDate(row.createdAt);
+        if (!createdAt || createdAt < fromDate) {
+          return false;
+        }
+      }
+      if (filter.to) {
+        const toDate = new Date(`${filter.to}T23:59:59`);
+        const createdAt = normalizeDate(row.createdAt);
+        if (!createdAt || createdAt > toDate) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [filter, maintainerById]);
+
+  const fetchRows = useCallback(async (mode: "reset" | "append" = "reset") => {
+    const shouldAppend = mode === "append";
+    const cursor = lastInspectionCursorRef.current;
+    if (shouldAppend && !cursor) return;
+
+    if (shouldAppend) {
+      setLoadingMoreRows(true);
+    } else {
+      setLoadingRows(true);
+      lastInspectionCursorRef.current = null;
+      setHasMoreRows(false);
+    }
     setError(null);
     try {
-      const snap = await getDocs(query(inspectionsCol, orderBy("createdAt", "desc")));
-      const allRows: ChecklistRow[] = snap.docs.map(docSnap => {
-        const data = docSnap.data() ?? {};
-        const machine = (data.machine ?? {}) as Record<string, unknown>;
-        const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
-        const template = (data.template ?? {}) as Record<string, unknown>;
-
-        const machineId = ensureString(machine.machineId) ?? ensureString(machine.id);
-        const machineFallback = machineId ? machineById.get(machineId) : null;
-        const maintainerId = ensureString(maintainer.maintId) ?? ensureString(maintainer.id);
-        const maintainerFallback = maintainerId ? maintainerById.get(maintainerId) : null;
-        const templateId = ensureString(template.id);
-        const templateFallback = templateId ? templateById.get(templateId) : null;
-
-        const ncCount = computeNcCount(data);
-
-        return {
-          id: docSnap.id,
-          createdAt: ensureString(data.createdAt) ?? ensureString(data.finalizadaEm) ?? ensureString(data.iniciadaEm),
-          machineId: machineId,
-          machineNome: ensureString(machine.nome) ?? machineFallback?.nome ?? null,
-          machineTag: ensureString(machine.tag) ?? machineFallback?.tag ?? null,
-          machineSetor: ensureString(machine.setor) ?? machineFallback?.setor ?? null,
-          maintainerId,
-          maintainerNome: ensureString(maintainer.nome) ?? maintainerFallback?.nome ?? null,
-          maintainerMatricula:
-            ensureString(maintainer.matricula) ?? maintainerFallback?.matricula ?? null,
-          templateId,
-          templateNome:
-            ensureString(template.nome) ?? ensureString(template.title) ?? templateFallback?.nome ?? null,
-          templateVersao:
-            ensureString(template.versao) ?? ensureString(template.version) ?? templateFallback?.versao ?? null,
-          osNumero: ensureString(data.osNumero),
-          ncCount,
-          hasNc: ncCount > 0,
-        } satisfies ChecklistRow;
-      });
-
-      const machineQuery = filter.machineTag?.trim().toLowerCase();
-      const selectedMaintainer =
-        filter.maintainerId === "all" ? null : maintainerById.get(filter.maintainerId) ?? null;
-
-      const filtered = allRows.filter(row => {
-        if (machineQuery) {
-          const tag = row.machineTag?.toLowerCase() ?? "";
-          const name = row.machineNome?.toLowerCase() ?? "";
-          const setor = row.machineSetor?.toLowerCase() ?? "";
-          if (!tag.includes(machineQuery) && !name.includes(machineQuery) && !setor.includes(machineQuery)) {
-            return false;
-          }
-        }
-        if (filter.maintainerId !== "all" && !rowMatchesMaintainer(row, selectedMaintainer)) {
-          return false;
-        }
-        if (filter.templateId !== "all" && row.templateId !== filter.templateId) {
-          return false;
-        }
-        if (filter.hasNc === "yes" && !row.hasNc) {
-          return false;
-        }
-        if (filter.hasNc === "no" && row.hasNc) {
-          return false;
-        }
-        if (filter.matricula?.trim()) {
-          const wanted = filter.matricula.trim().toLowerCase();
-          const matricula = row.maintainerMatricula?.toLowerCase() ?? "";
-          if (!matricula.includes(wanted)) {
-            return false;
-          }
-        }
-        if (filter.from) {
-          const fromDate = new Date(`${filter.from}T00:00:00`);
-          const createdAt = normalizeDate(row.createdAt);
-          if (!createdAt || createdAt < fromDate) {
-            return false;
-          }
-        }
-        if (filter.to) {
-          const toDate = new Date(`${filter.to}T23:59:59`);
-          const createdAt = normalizeDate(row.createdAt);
-          if (!createdAt || createdAt > toDate) {
-            return false;
-          }
-        }
-        return true;
-      });
-
-      setRows(filter.maintainerId === "all" ? filtered.slice(0, MAX_RESULTS) : filtered);
+      const constraints = shouldAppend && cursor
+        ? [orderBy("createdAt", "desc"), startAfter(cursor), limit(PAGE_SIZE)]
+        : [orderBy("createdAt", "desc"), limit(PAGE_SIZE)];
+      const snap = await getDocs(query(inspectionsCol, ...constraints));
+      const pageRows = applyCurrentFilters(snap.docs.map(mapInspectionDoc));
+      setRows(prev => (shouldAppend ? [...prev, ...pageRows] : pageRows));
+      lastInspectionCursorRef.current = snap.docs.at(-1) ?? null;
+      setHasMoreRows(snap.docs.length === PAGE_SIZE);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Erro ao carregar checklists";
       setError(message);
     } finally {
-      setLoadingRows(false);
+      if (shouldAppend) {
+        setLoadingMoreRows(false);
+      } else {
+        setLoadingRows(false);
+      }
     }
-  }, [filter, inspectionsCol, machineById, maintainerById, templateById]);
+  }, [applyCurrentFilters, inspectionsCol, mapInspectionDoc]);
 
   useEffect(() => {
     if (!loadingLookups) {
-      fetchRows();
+      fetchRows("reset");
     }
   }, [loadingLookups, fetchRows]);
 
@@ -436,7 +466,7 @@ export default function AdminChecklistsPage() {
         await deleteDoc(doc(inspectionsCol, row.id));
       }
       alert(`Checklists deletados com sucesso (${rows.length}).`);
-      await fetchRows();
+      await fetchRows("reset");
     } catch (err) {
       console.error("Erro ao deletar checklists", err);
       alert("Não foi possível deletar os checklists deste período. Tente novamente.");
@@ -460,7 +490,7 @@ export default function AdminChecklistsPage() {
           <Button
             size="sm"
             variant="outline"
-            onClick={() => fetchRows()}
+            onClick={() => fetchRows("reset")}
             disabled={loadingRows}
             loading={loadingRows}
           >
@@ -618,7 +648,7 @@ export default function AdminChecklistsPage() {
                   <i className="fas fa-eraser" aria-hidden />
                   Limpar filtros
                 </Button>
-                <Button size="sm" onClick={fetchRows} disabled={loadingRows} loading={loadingRows}>
+                <Button size="sm" onClick={() => fetchRows("reset")} disabled={loadingRows} loading={loadingRows}>
                   <i className="fas fa-filter" aria-hidden />
                   Aplicar filtros
                 </Button>
@@ -669,8 +699,9 @@ export default function AdminChecklistsPage() {
               icon={<i className="fas fa-clipboard-list" aria-hidden />}
             />
           ) : (
-            <Table>
-              <TableHeader>
+            <div className="space-y-4">
+              <Table>
+                <TableHeader>
                 <TableRow>
                   <TableHead>Data</TableHead>
                   <TableHead>Máquina</TableHead>
@@ -746,8 +777,23 @@ export default function AdminChecklistsPage() {
                     </TableCell>
                   </TableRow>
                 ))}
-              </TableBody>
-            </Table>
+                </TableBody>
+              </Table>
+              {hasMoreRows ? (
+                <div className="flex justify-center border-t border-[var(--border)] pt-4">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => fetchRows("append")}
+                    disabled={loadingMoreRows}
+                    loading={loadingMoreRows}
+                  >
+                    <i className="fas fa-plus" aria-hidden />
+                    Carregar mais 20 inspeções
+                  </Button>
+                </div>
+              ) : null}
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import {
   collection,
@@ -8,9 +8,14 @@ import {
   doc,
   getDoc,
   getDocs,
+  limit,
+  orderBy,
   query,
+  startAfter,
   updateDoc,
   where,
+  type DocumentData,
+  type QueryDocumentSnapshot,
 } from "firebase/firestore";
 import { firebaseDb } from "@/lib/firebase-client";
 import { Button } from "@/components/ui/button";
@@ -124,6 +129,11 @@ function formatDateInput(value: string | null | undefined) {
   return date.toISOString().slice(0, 10);
 }
 
+
+function normalizeOsNumero(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim().toUpperCase() : null;
+}
+
 function normalizeStatus(value: unknown): NonConformityStatus | null {
   if (value === "open" || value === "in_progress" || value === "resolved") {
     return value;
@@ -182,9 +192,7 @@ function normalizeAnswers(
           observation: typeof item.observacaoItem === "string" ? item.observacaoItem : null,
           photoUrls: normalizeStoredImages(item.fotos ?? []),
           recurrence: false,
-          itemOsNumero: typeof item.osNumeroItem === "string" && item.osNumeroItem.trim()
-            ? item.osNumeroItem.trim().toUpperCase()
-            : null,
+          itemOsNumero: normalizeOsNumero(item.osNumeroItem),
         } satisfies ChecklistAnswer;
       })
   );
@@ -215,7 +223,7 @@ function normalizeAnswers(
           observation: item.observation ?? fallbackFromItens?.observation ?? null,
           photoUrls: mergeStoredImageCollections(item.photoUrls, fallbackFromItens?.photoUrls),
           recurrence: item.recurrence === true || fallbackFromItens?.recurrence === true,
-          itemOsNumero: item.itemOsNumero ?? fallbackFromItens?.itemOsNumero ?? null,
+          itemOsNumero: normalizeOsNumero(item.itemOsNumero) ?? fallbackFromItens?.itemOsNumero ?? null,
         } satisfies ChecklistAnswer;
       })
   );
@@ -245,6 +253,9 @@ function renderStatusBadge(status: NonConformityStatus) {
   return <Badge variant="danger">Aberta</Badge>;
 }
 
+const PAGE_SIZE = 20;
+type IssueCursor = QueryDocumentSnapshot<DocumentData>;
+
 const STATUS_OPTIONS: Array<{ value: NonConformityStatus; label: string }> = [
   { value: "open", label: "Aberta" },
   { value: "in_progress", label: "Em andamento" },
@@ -253,6 +264,11 @@ const STATUS_OPTIONS: Array<{ value: NonConformityStatus; label: string }> = [
 
 export default function AdminNonConformitiesPage() {
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const issueCursorRef = useRef<IssueCursor | null>(null);
+  const [hasMoreInitialItems, setHasMoreInitialItems] = useState(false);
+  const [usingInitialLimit, setUsingInitialLimit] = useState(true);
+  const [forceVisibleIds, setForceVisibleIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<NonConformityItem[]>([]);
   const [treatmentsByResponse, setTreatmentsByResponse] = useState<Record<string, ChecklistNonConformityTreatment[]>>({});
@@ -268,12 +284,25 @@ export default function AdminNonConformitiesPage() {
   const [deleteDialogItem, setDeleteDialogItem] = useState<NonConformityItem | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
+  const hasActiveFilter = Boolean(machineFilter.trim() || maintainerFilter || statusFilter !== "open" || dueDateFilter !== "default");
+
   useEffect(() => {
     setSelectedIds(prev => prev.filter(id => items.some(item => item.id === id)));
   }, [items]);
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
+  const loadData = useCallback(async (mode: "initial" | "append" | "full" = "initial") => {
+    const append = mode === "append";
+    const fullLoad = mode === "full";
+    if (append && !issueCursorRef.current) return;
+
+    if (append) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+      issueCursorRef.current = null;
+      setHasMoreInitialItems(false);
+      setUsingInitialLimit(!fullLoad);
+    }
     setError(null);
     try {
       const session = await fetch("/api/admin-session", { cache: "no-store" });
@@ -282,10 +311,25 @@ export default function AdminNonConformitiesPage() {
         return;
       }
 
+      const issueConstraints = fullLoad
+        ? [where("status", "in", ["aberta", "concluida", "resolvida"])]
+        : append && issueCursorRef.current
+          ? [
+              where("status", "in", ["aberta", "concluida", "resolvida"]),
+              orderBy("updatedAt", "desc"),
+              startAfter(issueCursorRef.current),
+              limit(PAGE_SIZE),
+            ]
+          : [
+              where("status", "in", ["aberta", "concluida", "resolvida"]),
+              orderBy("updatedAt", "desc"),
+              limit(PAGE_SIZE),
+            ];
+
       const [machinesSnap, templatesSnap, issuesSnap] = await Promise.all([
         getDocs(collection(firebaseDb, "machines")),
         getDocs(collection(firebaseDb, "templates")),
-        getDocs(query(collection(firebaseDb, "issues"), where("status", "in", ["aberta", "concluida", "resolvida"]))),
+        getDocs(query(collection(firebaseDb, "issues"), ...issueConstraints)),
       ]);
 
       const machineOptions: MachineOption[] = machinesSnap.docs.map(docSnap => {
@@ -320,13 +364,11 @@ export default function AdminNonConformitiesPage() {
       const sourceInspectionIds = Array.from(
         new Set(
           issuesSnap.docs
-            .map(issueDoc => {
+            .flatMap(issueDoc => {
               const issueData = issueDoc.data() ?? {};
-              return typeof issueData.abertaEmInspecaoId === "string"
-                ? issueData.abertaEmInspecaoId
-                : null;
+              return [issueData.abertaEmInspecaoId, issueData.ultimaReincidenciaInspecaoId]
+                .filter((value): value is string => typeof value === "string" && value.trim().length > 0);
             })
-            .filter((value): value is string => Boolean(value))
         )
       );
 
@@ -412,7 +454,9 @@ export default function AdminNonConformitiesPage() {
 
         const responseId =
           typeof issueData.abertaEmInspecaoId === "string" ? issueData.abertaEmInspecaoId : null;
-        const sourceInspection = responseId ? sourceInspectionMap.get(responseId) : undefined;
+        const latestOccurrenceId =
+          typeof issueData.ultimaReincidenciaInspecaoId === "string" ? issueData.ultimaReincidenciaInspecaoId : responseId;
+        const sourceInspection = latestOccurrenceId ? sourceInspectionMap.get(latestOccurrenceId) : undefined;
         const machineOption = machineId ? machinesById.get(machineId) : undefined;
         const issueTag = typeof issueData.tag === "string" ? issueData.tag : null;
         const templateId = sourceInspection?.templateId ?? machineOption?.templateId ?? null;
@@ -494,9 +538,9 @@ export default function AdminNonConformitiesPage() {
               : answerData?.observation ?? null,
           photos: mergeStoredImageCollections(issueData.fotos, answerData?.photoUrls),
           itemOsNumero:
-            typeof issueData.osNumero === "string"
-              ? issueData.osNumero
-              : answerData?.itemOsNumero ?? null,
+            answerData?.itemOsNumero ??
+            normalizeOsNumero(issueData.osNumero) ??
+            null,
           issueStatus,
           status,
           summary: summaryValue ? String(summaryValue) : "",
@@ -510,19 +554,38 @@ export default function AdminNonConformitiesPage() {
         });
       });
 
-      setItems(sortByLastActivityDesc(builtItems));
-      setTreatmentsByResponse(treatmentsRecord);
+      setTreatmentsByResponse(prev => (append ? { ...prev, ...treatmentsRecord } : treatmentsRecord));
+      setItems(prev => {
+        const nextItems = sortByLastActivityDesc(builtItems);
+        if (!append) return nextItems;
+        const merged = new Map(prev.map(item => [item.id, item] as const));
+        nextItems.forEach(item => merged.set(item.id, item));
+        return sortByLastActivityDesc(Array.from(merged.values()));
+      });
+      issueCursorRef.current = issuesSnap.docs.at(-1) ?? null;
+      setHasMoreInitialItems(!fullLoad && issuesSnap.docs.length === PAGE_SIZE);
     } catch (err: unknown) {
       const message = err instanceof Error && err.message ? err.message : "Erro ao carregar dados";
       setError(message);
     } finally {
-      setLoading(false);
+      if (append) {
+        setLoadingMore(false);
+      } else {
+        setLoading(false);
+      }
     }
   }, []);
 
   useEffect(() => {
-    loadData();
+    loadData("initial");
   }, [loadData]);
+
+  useEffect(() => {
+    setForceVisibleIds(new Set());
+    if (hasActiveFilter && usingInitialLimit) {
+      loadData("full");
+    }
+  }, [dueDateFilter, hasActiveFilter, loadData, machineFilter, maintainerFilter, statusFilter, usingInitialLimit]);
 
   const machineOptionsForFilter = useMemo(() => {
     return Array.from(new Set(items.map(item => item.machineLabel.trim()).filter(Boolean))).sort((a, b) =>
@@ -547,6 +610,9 @@ export default function AdminNonConformitiesPage() {
   const filteredItems = useMemo(() => {
     const machineSearch = machineFilter.trim().toLowerCase();
     const visibleItems = items.filter(item => {
+      if (forceVisibleIds.has(item.id)) {
+        return true;
+      }
       if (machineSearch) {
         const machineLabel = item.machineLabel.toLowerCase();
         const machineTag = (item.machineTag ?? "").toLowerCase();
@@ -582,9 +648,14 @@ export default function AdminNonConformitiesPage() {
     }
 
     return visibleItems;
-  }, [items, machineFilter, maintainerFilter, statusFilter, dueDateFilter]);
+  }, [items, machineFilter, maintainerFilter, statusFilter, dueDateFilter, forceVisibleIds]);
+
+  const keepItemVisibleInCurrentFilter = useCallback((id: string) => {
+    setForceVisibleIds(prev => new Set(prev).add(id));
+  }, []);
 
   const handleUpdateItem = useCallback((id: string, updates: Partial<NonConformityItem>) => {
+    setForceVisibleIds(prev => new Set(prev).add(id));
     setItems(prev => prev.map(item => (item.id === id ? { ...item, ...updates } : item)));
   }, []);
 
@@ -668,10 +739,11 @@ export default function AdminNonConformitiesPage() {
   const handleStatusClick = useCallback(
     async (item: NonConformityItem, status: NonConformityStatus) => {
       const updatedItem = { ...item, status };
+      keepItemVisibleInCurrentFilter(item.id);
       handleUpdateItem(item.id, { status });
       await handleSave(updatedItem);
     },
-    [handleSave, handleUpdateItem]
+    [handleSave, handleUpdateItem, keepItemVisibleInCurrentFilter]
   );
 
   const handleBulkStatusChange = useCallback(
@@ -683,6 +755,7 @@ export default function AdminNonConformitiesPage() {
       try {
         for (const target of targetItems) {
           const updatedItem = { ...target, status };
+          keepItemVisibleInCurrentFilter(target.id);
           handleUpdateItem(target.id, { status });
           await handleSave(updatedItem);
         }
@@ -690,7 +763,7 @@ export default function AdminNonConformitiesPage() {
         setBulkSaving(false);
       }
     },
-    [handleSave, handleUpdateItem, items, selectedIds]
+    [handleSave, handleUpdateItem, items, keepItemVisibleInCurrentFilter, selectedIds]
   );
 
   const handleToggleItemSelection = useCallback((id: string) => {
@@ -737,6 +810,11 @@ export default function AdminNonConformitiesPage() {
 
       setItems(prev => prev.filter(item => item.id !== deleteDialogItem.id));
       setSelectedIds(prev => prev.filter(id => id !== deleteDialogItem.id));
+      setForceVisibleIds(prev => {
+        const next = new Set(prev);
+        next.delete(deleteDialogItem.id);
+        return next;
+      });
       setFeedback(prev => {
         const next = { ...prev };
         delete next[deleteDialogItem.id];
@@ -754,6 +832,7 @@ export default function AdminNonConformitiesPage() {
   const allVisibleSelected =
     filteredItems.length > 0 && filteredItems.every(item => selectedIds.includes(item.id));
   const selectedCount = selectedIds.length;
+  const canLoadMoreInitialItems = usingInitialLimit && hasMoreInitialItems;
 
   if (loading) {
     return (
@@ -791,7 +870,7 @@ export default function AdminNonConformitiesPage() {
             <h1 className="text-2xl font-semibold text-[var(--text)]">Não conformidades</h1>
             <p className="text-sm text-[var(--muted)]">Visualize e trate as respostas marcadas como NC.</p>
           </div>
-          <Button variant="secondary" onClick={() => loadData()}>
+          <Button variant="secondary" onClick={() => loadData(hasActiveFilter ? "full" : "initial")}>
             Recarregar
           </Button>
         </header>
@@ -809,7 +888,7 @@ export default function AdminNonConformitiesPage() {
           <h1 className="text-2xl font-semibold text-[var(--text)]">Não conformidades</h1>
           <p className="text-sm text-[var(--muted)]">Somente respostas &quot;NC&quot; aparecem nesta lista para tratativa.</p>
         </div>
-        <Button variant="secondary" onClick={() => loadData()}>
+        <Button variant="secondary" onClick={() => loadData(hasActiveFilter ? "full" : "initial")}>
           Recarregar
         </Button>
       </header>
@@ -914,10 +993,25 @@ export default function AdminNonConformitiesPage() {
       )}
 
       {filteredItems.length === 0 ? (
-        <EmptyState
-          title="Nenhuma não conformidade encontrada"
-          description="Ajuste os filtros ou aguarde novas inspeções com NC registradas."
-        />
+        <div className="space-y-4">
+          <EmptyState
+            title="Nenhuma não conformidade encontrada"
+            description="Ajuste os filtros ou aguarde novas inspeções com NC registradas."
+          />
+          {canLoadMoreInitialItems ? (
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => loadData("append")}
+                disabled={loadingMore}
+                loading={loadingMore}
+              >
+                Carregar mais 20 NC
+              </Button>
+            </div>
+          ) : null}
+        </div>
       ) : (
         <div className="space-y-6">
           {filteredItems.map(item => {
@@ -1127,6 +1221,19 @@ export default function AdminNonConformitiesPage() {
               </article>
             );
           })}
+          {canLoadMoreInitialItems ? (
+            <div className="flex justify-center pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => loadData("append")}
+                disabled={loadingMore}
+                loading={loadingMore}
+              >
+                Carregar mais 20 NC
+              </Button>
+            </div>
+          ) : null}
         </div>
       )}
 

--- a/src/app/api/admin/nc/route.ts
+++ b/src/app/api/admin/nc/route.ts
@@ -110,6 +110,11 @@ function formatDateInput(value: string | null | undefined) {
   return date.toISOString().slice(0, 10);
 }
 
+
+function normalizeOsNumero(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim().toUpperCase() : null;
+}
+
 function normalizeStatus(value: unknown): NonConformityStatus | null {
   if (value === "open" || value === "in_progress" || value === "resolved") {
     return value;
@@ -174,9 +179,7 @@ function normalizeAnswers(
           photoUrls: normalizeStoredImages(item.fotos ?? []),
           recurrence: false,
           itemOsNumero:
-            typeof item.osNumeroItem === "string" && item.osNumeroItem.trim()
-              ? item.osNumeroItem.trim().toUpperCase()
-              : null,
+            normalizeOsNumero(item.osNumeroItem),
         } satisfies ChecklistAnswer;
       })
   );
@@ -205,7 +208,7 @@ function normalizeAnswers(
           observation: item.observation ?? fallbackFromItens?.observation ?? null,
           photoUrls: mergeStoredImageCollections(item.photoUrls, fallbackFromItens?.photoUrls),
           recurrence: item.recurrence === true || fallbackFromItens?.recurrence === true,
-          itemOsNumero: item.itemOsNumero ?? fallbackFromItens?.itemOsNumero ?? null,
+          itemOsNumero: normalizeOsNumero(item.itemOsNumero) ?? fallbackFromItens?.itemOsNumero ?? null,
         } satisfies ChecklistAnswer;
       })
   );
@@ -336,10 +339,7 @@ export async function GET(req: NextRequest) {
       const questionId = String(answer.questionId);
       const logicalId = buildNcLogicalId(machineId, machineTag, questionId);
       const inspectionDate = resolveInspectionDate(inspectionData);
-      const itemOsNumero =
-        typeof answer.itemOsNumero === "string" && answer.itemOsNumero.trim()
-          ? answer.itemOsNumero.trim().toUpperCase()
-          : null;
+      const itemOsNumero = normalizeOsNumero(answer.itemOsNumero);
       const observation = answer.observation ?? null;
       const currentHistory = ncHistoryByLogicalId.get(logicalId) ?? [];
       currentHistory.push({
@@ -362,7 +362,9 @@ export async function GET(req: NextRequest) {
     if (!questionId) return;
 
     const responseId = typeof issueData.abertaEmInspecaoId === "string" ? issueData.abertaEmInspecaoId : null;
-    const sourceInspection = responseId ? sourceInspectionMap.get(responseId) : undefined;
+    const latestOccurrenceId =
+      typeof issueData.ultimaReincidenciaInspecaoId === "string" ? issueData.ultimaReincidenciaInspecaoId : responseId;
+    const sourceInspection = latestOccurrenceId ? sourceInspectionMap.get(latestOccurrenceId) : undefined;
     const machineOption = machineId ? machinesById.get(machineId) : undefined;
     const issueTag = typeof issueData.tag === "string" ? issueData.tag : null;
     const templateId = sourceInspection?.templateId ?? machineOption?.templateId ?? null;
@@ -434,7 +436,7 @@ export async function GET(req: NextRequest) {
       operatorMatricula: sourceInspection?.operatorMatricula ?? null,
       observation: typeof issueData.descricao === "string" ? issueData.descricao : answerData?.observation ?? null,
       photos: mergeStoredImageCollections(issueData.fotos, answerData?.photoUrls),
-      itemOsNumero: typeof issueData.osNumero === "string" ? issueData.osNumero : answerData?.itemOsNumero ?? null,
+      itemOsNumero: answerData?.itemOsNumero ?? normalizeOsNumero(issueData.osNumero) ?? null,
       issueStatus,
       status,
       summary: summaryValue ? String(summaryValue) : "",

--- a/src/app/api/programacao/upload/route.ts
+++ b/src/app/api/programacao/upload/route.ts
@@ -282,7 +282,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const buffer = Buffer.from(await file.arrayBuffer());
-    const rows = parseCsv(buffer, { delimiter: ",", skipEmptyLines: true }) as RawRow[];
+    const rows = parseCsv(buffer, { skipEmptyLines: true }) as RawRow[];
 
     if (!rows.length) {
       return NextResponse.json({ error: "EMPTY_CSV" }, { status: 400 });

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -7,11 +7,9 @@ export interface ParseCsvOptions {
   skipEmptyLines?: boolean;
 }
 
-export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}): CsvRow[] {
-  const delimiter = options.delimiter ?? ",";
-  const skipEmptyLines = options.skipEmptyLines ?? true;
+const CANDIDATE_DELIMITERS = [",", ";", "\t"] as const;
 
-  const text = (typeof content === "string" ? content : content.toString("utf-8")).replace(/^\ufeff/, "");
+function splitCsvRows(text: string, delimiter: string, skipEmptyLines: boolean): string[][] {
   const rows: string[][] = [];
   let currentField = "";
   let currentRow: string[] = [];
@@ -69,6 +67,36 @@ export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}
     pushRow();
   }
 
+  return rows;
+}
+
+function scoreRows(rows: string[][]) {
+  if (!rows.length) return 0;
+  const [header, ...dataRows] = rows;
+  const headerColumns = header.length;
+  const comparableRows = dataRows.slice(0, 25);
+  const matchingRows = comparableRows.filter(row => row.length === headerColumns).length;
+  const populatedHeaders = header.filter(column => column.trim().length > 0).length;
+
+  return headerColumns * 100 + populatedHeaders * 10 + matchingRows;
+}
+
+function detectDelimiter(text: string, skipEmptyLines: boolean) {
+  return CANDIDATE_DELIMITERS.map(delimiter => ({
+    delimiter,
+    rows: splitCsvRows(text, delimiter, skipEmptyLines),
+  })).sort((a, b) => scoreRows(b.rows) - scoreRows(a.rows))[0]!;
+}
+
+export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}): CsvRow[] {
+  const skipEmptyLines = options.skipEmptyLines ?? true;
+
+  const text = (typeof content === "string" ? content : content.toString("utf-8")).replace(/^\ufeff/, "");
+  const parsed = options.delimiter
+    ? { delimiter: options.delimiter, rows: splitCsvRows(text, options.delimiter, skipEmptyLines) }
+    : detectDelimiter(text, skipEmptyLines);
+  const { delimiter, rows } = parsed;
+
   if (!rows.length) {
     return [];
   }
@@ -78,9 +106,12 @@ export function parseCsv(content: string | Buffer, options: ParseCsvOptions = {}
   const records: CsvRow[] = [];
 
   for (const dataRow of dataRows) {
+    const normalizedRow = dataRow.length === 1 && headers.length > 1 && dataRow[0]?.includes(delimiter)
+      ? splitCsvRows(dataRow[0], delimiter, false)[0] ?? dataRow
+      : dataRow;
     const record: CsvRow = {};
     headers.forEach((column, index) => {
-      record[column] = (dataRow[index] ?? "").trim();
+      record[column] = (normalizedRow[index] ?? "").trim();
     });
     records.push(record);
   }

--- a/src/lib/non-conformity-priority.ts
+++ b/src/lib/non-conformity-priority.ts
@@ -9,6 +9,10 @@ export interface IssueRecurrenceUpdateInput {
   descricao?: string | null;
 }
 
+function normalizeOsNumero(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim().toUpperCase() : null;
+}
+
 export function buildIssueRecurrenceUpdates({
   issueData,
   inspectionId,
@@ -26,8 +30,9 @@ export function buildIssueRecurrenceUpdates({
     updatedAt: nowIso,
   };
 
-  if (osNumeroItem && issueData.osNumero !== osNumeroItem) {
-    updates.osNumero = osNumeroItem;
+  const normalizedOsNumeroItem = normalizeOsNumero(osNumeroItem);
+  if (normalizedOsNumeroItem && normalizeOsNumero(issueData.osNumero) !== normalizedOsNumeroItem) {
+    updates.osNumero = normalizedOsNumeroItem;
   }
   if (fotos.length > 0) {
     updates.fotos = fotos;


### PR DESCRIPTION
### Motivation

- Improve performance and UX when listing large numbers of inspections and non-conformities by adding pagination and incremental loading. 
- Make CSV uploads more robust by auto-detecting common delimiters and handling messy rows. 
- Ensure OS numbers are normalized consistently across NC building, API responses and recurrence updates to avoid mismatches.

### Description

- Implemented paginated loading for inspections in `src/app/admin/checklists/page.tsx` using Firestore `limit`/`startAfter`, added cursor refs, `PAGE_SIZE`, `hasMoreRows` and a "Carregar mais" button, and refactored mapping/filters into `mapInspectionDoc` and `applyCurrentFilters`.
- Added paginated and conditional loading modes to non-conformities in `src/app/admin/nc/page.tsx` with `PAGE_SIZE`, cursor handling, `initial|append|full` load modes, `forceVisibleIds` to keep updated items visible after edits, and load-more buttons and related loading states.
- Normalized OS number handling by introducing `normalizeOsNumero` and applying it in the API handler `src/app/api/admin/nc/route.ts`, in `src/lib/non-conformity-priority.ts`, and in the NC page logic so `osNumero` and `itemOsNumero` are consistently uppercased and trimmed when present; also prefer the latest occurrence id (`ultimaReincidenciaInspecaoId`) when building NC items.
- Rewrote CSV parsing in `src/lib/csv.ts` to auto-detect delimiter among `,`, `;`, and `	`, robustly split rows and quoted fields, handle rows that may appear as a single field containing the delimiter, and kept `skipEmptyLines` support; removed forcing a `delimiter` argument in the upload handler `src/app/api/programacao/upload/route.ts` so it uses autodetection.

### Testing

- No new automated tests were added for these changes. 
- Performed a local TypeScript typecheck which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42c22a6fd8832895d89711cd8ce65a)