### PR TITLE
Add client-side caching, pagination and stats for admin pages; enable Firestore persistent cache

### DIFF
--- a/src/app/admin/checklists/page.tsx
+++ b/src/app/admin/checklists/page.tsx
@@ -159,6 +159,27 @@ function computeNcCount(data: Record<string, unknown>): number {
 
 const PAGE_SIZE = 20;
 const FILTERED_PAGE_SIZE = 100;
+const MACHINES_SESSION_CACHE_KEY = "admin-checklists-machines-v1";
+const TEMPLATES_SESSION_CACHE_KEY = "admin-checklists-templates-v1";
+
+function readSessionCache<T>(key: string): T[] | null {
+  if (typeof window === "undefined") return null;
+  const cached = window.sessionStorage.getItem(key);
+  if (!cached) return null;
+  try {
+    const parsed = JSON.parse(cached);
+    return Array.isArray(parsed) ? (parsed as T[]) : null;
+  } catch {
+    window.sessionStorage.removeItem(key);
+    return null;
+  }
+}
+
+function writeSessionCache<T>(key: string, records: T[]) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(key, JSON.stringify(records));
+}
+
 type InspectionCursor = QueryDocumentSnapshot<DocumentData>;
 
 export default function AdminChecklistsPage() {
@@ -197,15 +218,18 @@ export default function AdminChecklistsPage() {
           return;
         }
 
+        const cachedMachines = readSessionCache<MachineOption>(MACHINES_SESSION_CACHE_KEY);
+        const cachedTemplates = readSessionCache<TemplateOption>(TEMPLATES_SESSION_CACHE_KEY);
+
         const [machinesSnap, maintainersSnap, templatesSnap] = await Promise.all([
-          getDocs(machinesCol),
+          cachedMachines ? Promise.resolve(null) : getDocs(machinesCol),
           getDocs(maintainersCol),
-          getDocs(templatesCol),
+          cachedTemplates ? Promise.resolve(null) : getDocs(templatesCol),
         ]);
 
         if (cancelled) return;
 
-        const machineRecords: MachineOption[] = machinesSnap.docs
+        const machineRecords: MachineOption[] = cachedMachines ?? machinesSnap!.docs
           .map(docSnap => {
             const data = docSnap.data() ?? {};
             return {
@@ -221,6 +245,7 @@ export default function AdminChecklistsPage() {
             const labelB = (b.nome ?? b.tag ?? "").toLowerCase();
             return labelA.localeCompare(labelB);
           });
+        if (!cachedMachines) writeSessionCache(MACHINES_SESSION_CACHE_KEY, machineRecords);
 
         const maintainerRecords: MaintainerOption[] = maintainersSnap.docs
           .map(docSnap => {
@@ -237,7 +262,7 @@ export default function AdminChecklistsPage() {
             return labelA.localeCompare(labelB);
           });
 
-        const templateRecords: TemplateOption[] = templatesSnap.docs
+        const templateRecords: TemplateOption[] = cachedTemplates ?? templatesSnap!.docs
           .map(docSnap => {
             const data = docSnap.data() ?? {};
             return {
@@ -251,6 +276,7 @@ export default function AdminChecklistsPage() {
             const labelB = (b.nome ?? "").toLowerCase();
             return labelA.localeCompare(labelB);
           });
+        if (!cachedTemplates) writeSessionCache(TEMPLATES_SESSION_CACHE_KEY, templateRecords);
 
         setMachines(machineRecords);
         setMaintainers(maintainerRecords);

--- a/src/app/admin/inspecoes/page.tsx
+++ b/src/app/admin/inspecoes/page.tsx
@@ -1,8 +1,19 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { collection, getDocs, orderBy, query } from "firebase/firestore";
+import {
+  collection,
+  getCountFromServer,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  where,
+  type DocumentData,
+  type QueryDocumentSnapshot,
+} from "firebase/firestore";
 import { firebaseDb } from "@/lib/firebase-client";
 import { Button, buttonStyles } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -39,6 +50,43 @@ interface InspectionListItem {
   ncItems: Array<{ questionId: string; questionText: string | null; osNumero: string | null; photoUrls: StoredImage[] }>;
 }
 
+
+interface InspectionStats {
+  total: number;
+  signed: number;
+  pending: number;
+  withNc: number;
+}
+
+const PAGE_SIZE = 20;
+type InspectionCursor = QueryDocumentSnapshot<DocumentData>;
+
+const emptyStats: InspectionStats = {
+  total: 0,
+  signed: 0,
+  pending: 0,
+  withNc: 0,
+};
+
+async function loadInspectionStats(): Promise<InspectionStats> {
+  const inspectionsRef = collection(firebaseDb, "inspecoes");
+  const [totalSnap, signedSnap, withNcSnap] = await Promise.all([
+    getCountFromServer(inspectionsRef),
+    getCountFromServer(query(inspectionsRef, where("pcmSign.assinaturaUrl", ">", ""))),
+    getCountFromServer(query(inspectionsRef, where("qtdNC", ">", 0))),
+  ]);
+
+  const total = totalSnap.data().count;
+  const signed = signedSnap.data().count;
+
+  return {
+    total,
+    signed,
+    pending: Math.max(total - signed, 0),
+    withNc: withNcSnap.data().count,
+  };
+}
+
 function formatDateTime(value: string | null) {
   if (!value) return "-";
   const date = new Date(value);
@@ -46,118 +94,143 @@ function formatDateTime(value: string | null) {
   return date.toLocaleString("pt-BR");
 }
 
+
+function mapInspectionDoc(doc: InspectionCursor): InspectionListItem {
+  const data = doc.data() ?? {};
+  const machine = (data.machine ?? {}) as Record<string, unknown>;
+  const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  const itensRaw = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  const ncItems =
+    answers.length > 0
+      ? answers
+          .filter(answer => answer?.response === "nc")
+          .map(answer => ({
+            questionId: answer.questionId,
+            questionText: answer.questionText ?? null,
+            osNumero: answer.itemOsNumero ?? null,
+            photoUrls: normalizeStoredImages(answer.photoUrls ?? []),
+          }))
+      : itensRaw
+          .filter(item => String(item.resultado ?? item.response ?? "C").toLowerCase() === "nc")
+          .map(item => ({
+            questionId: String(item.templateItemId ?? item.questionId ?? ""),
+            questionText:
+              typeof item.componente === "string"
+                ? item.componente
+                : typeof item.criterio === "string"
+                ? item.criterio
+                : null,
+            osNumero:
+              typeof item.osNumeroItem === "string" && item.osNumeroItem.trim()
+                ? item.osNumeroItem.trim().toUpperCase()
+                : null,
+            photoUrls: normalizeStoredImages(item.fotos ?? []),
+          }));
+  const qtdNc = typeof data.qtdNC === "number" ? data.qtdNC : ncItems.length;
+  const pcmSign = (data.pcmSign ?? {}) as Record<string, unknown>;
+  const maintainerId =
+    typeof maintainer.id === "string" && maintainer.id.trim()
+      ? maintainer.id.trim()
+      : typeof maintainer.maintId === "string" && maintainer.maintId.trim()
+      ? maintainer.maintId.trim()
+      : null;
+  const maintainerMatricula =
+    typeof maintainer.matricula === "string" && maintainer.matricula.trim()
+      ? maintainer.matricula.trim().toUpperCase()
+      : null;
+  const maintainerNome = maintainer.nome ? String(maintainer.nome) : null;
+  const maintainerKey =
+    maintainerId ??
+    maintainerMatricula ??
+    (maintainerNome ? maintainerNome.trim().toLowerCase() : null) ??
+    "unknown";
+
+  return {
+    id: doc.id,
+    machineNome: machine.nome ? String(machine.nome) : null,
+    machineTag: machine.tag ? String(machine.tag) : null,
+    createdAt: data.createdAt ? String(data.createdAt) : null,
+    maintainerNome,
+    maintainerMatricula,
+    maintainerId,
+    maintainerKey,
+    qtdNc,
+    hasNc: qtdNc > 0,
+    osNumero: data.osNumero ? String(data.osNumero) : null,
+    signed: Boolean(pcmSign && pcmSign.assinaturaUrl),
+    signedAt: pcmSign?.signedAt ? String(pcmSign.signedAt) : null,
+    pcmNome: pcmSign?.nome ? String(pcmSign.nome) : null,
+    ncItems,
+  };
+}
+
 export default function AdminInspectionsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<InspectionListItem[]>([]);
+  const [stats, setStats] = useState<InspectionStats>(emptyStats);
   const [selectedMaintainers, setSelectedMaintainers] = useState<string[]>([]);
-  const [visibleCount, setVisibleCount] = useState<number>(0);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMoreItems, setHasMoreItems] = useState(false);
+  const lastInspectionCursorRef = useRef<InspectionCursor | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [actionFeedback, setActionFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
+  const fetchInspectionPage = useCallback(async (mode: "reset" | "append" = "reset") => {
+    const shouldAppend = mode === "append";
+    const cursor = lastInspectionCursorRef.current;
+    if (shouldAppend && !cursor) return;
+
+    if (shouldAppend) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+      lastInspectionCursorRef.current = null;
+      setHasMoreItems(false);
+      setActionFeedback(null);
+    }
     setError(null);
-    setActionFeedback(null);
+
     try {
-      const session = await fetch("/api/admin-session", { cache: "no-store" });
-      if (session.status === 401) {
-        window.location.href = "/admin/login";
-        setLoading(false);
-        return;
+      if (!shouldAppend) {
+        const session = await fetch("/api/admin-session", { cache: "no-store" });
+        if (session.status === 401) {
+          window.location.href = "/admin/login";
+          return;
+        }
       }
 
-      const inspectionsSnap = await getDocs(
-        query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"))
-      );
+      const inspectionsQuery = cursor && shouldAppend
+        ? query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"), startAfter(cursor), limit(PAGE_SIZE))
+        : query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"), limit(PAGE_SIZE));
 
-      const mapped: InspectionListItem[] = inspectionsSnap.docs.map(doc => {
-        const data = doc.data() ?? {};
-        const machine = (data.machine ?? {}) as Record<string, unknown>;
-        const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
-        const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
-        const itensRaw = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
-        const ncItems =
-          answers.length > 0
-            ? answers
-                .filter(answer => answer?.response === "nc")
-                .map(answer => ({
-                  questionId: answer.questionId,
-                  questionText: answer.questionText ?? null,
-                  osNumero: answer.itemOsNumero ?? null,
-                  photoUrls: normalizeStoredImages(answer.photoUrls ?? []),
-                }))
-            : itensRaw
-                .filter(item => String(item.resultado ?? item.response ?? "C").toLowerCase() === "nc")
-                .map(item => ({
-                  questionId: String(item.templateItemId ?? item.questionId ?? ""),
-                  questionText:
-                    typeof item.componente === "string"
-                      ? item.componente
-                      : typeof item.criterio === "string"
-                      ? item.criterio
-                      : null,
-                  osNumero:
-                    typeof item.osNumeroItem === "string" && item.osNumeroItem.trim()
-                      ? item.osNumeroItem.trim().toUpperCase()
-                      : null,
-                  photoUrls: normalizeStoredImages(item.fotos ?? []),
-                }));
-        const qtdNc = typeof data.qtdNC === "number" ? data.qtdNC : ncItems.length;
-        const pcmSign = (data.pcmSign ?? {}) as Record<string, unknown>;
-        const maintainerId =
-          typeof maintainer.id === "string" && maintainer.id.trim()
-            ? maintainer.id.trim()
-            : typeof maintainer.maintId === "string" && maintainer.maintId.trim()
-            ? maintainer.maintId.trim()
-            : null;
-        const maintainerMatricula =
-          typeof maintainer.matricula === "string" && maintainer.matricula.trim()
-            ? maintainer.matricula.trim().toUpperCase()
-            : null;
-        const maintainerNome = maintainer.nome ? String(maintainer.nome) : null;
-        const maintainerKey =
-          maintainerId ??
-          maintainerMatricula ??
-          (maintainerNome ? maintainerNome.trim().toLowerCase() : null) ??
-          "unknown";
+      const [inspectionsSnap, inspectionStats] = await Promise.all([
+        getDocs(inspectionsQuery),
+        shouldAppend ? Promise.resolve(null) : loadInspectionStats(),
+      ]);
 
-        return {
-          id: doc.id,
-          machineNome: machine.nome ? String(machine.nome) : null,
-          machineTag: machine.tag ? String(machine.tag) : null,
-          createdAt: data.createdAt ? String(data.createdAt) : null,
-          maintainerNome,
-          maintainerMatricula,
-          maintainerId,
-          maintainerKey,
-          qtdNc,
-          hasNc: qtdNc > 0,
-          osNumero: data.osNumero ? String(data.osNumero) : null,
-          signed: Boolean(pcmSign && pcmSign.assinaturaUrl),
-          signedAt: pcmSign?.signedAt ? String(pcmSign.signedAt) : null,
-          pcmNome: pcmSign?.nome ? String(pcmSign.nome) : null,
-          ncItems,
-        } satisfies InspectionListItem;
-      });
-
-      setItems(mapped);
+      const mapped = inspectionsSnap.docs.map(mapInspectionDoc);
+      setItems(prev => (shouldAppend ? [...prev, ...mapped] : mapped));
+      if (inspectionStats) {
+        setStats(inspectionStats);
+      }
+      lastInspectionCursorRef.current = inspectionsSnap.docs.at(-1) ?? null;
+      setHasMoreItems(inspectionsSnap.docs.length === PAGE_SIZE);
     } catch (err: unknown) {
       const message = err instanceof Error && err.message ? err.message : "Erro ao carregar inspeções";
       setError(message);
     } finally {
-      setLoading(false);
+      if (shouldAppend) {
+        setLoadingMore(false);
+      } else {
+        setLoading(false);
+      }
     }
   }, []);
 
-  useEffect(() => {
-    setVisibleCount(prev => {
-      if (selectedMaintainers.length === 0) {
-        return 0;
-      }
-      return prev === 0 ? 10 : prev;
-    });
-  }, [selectedMaintainers]);
+  const loadData = useCallback(() => fetchInspectionPage("reset"), [fetchInspectionPage]);
+  const handleLoadMore = useCallback(() => fetchInspectionPage("append"), [fetchInspectionPage]);
 
   useEffect(() => {
     loadData();
@@ -171,8 +244,17 @@ export default function AdminInspectionsPage() {
     const handler = (event: MessageEvent) => {
       const data = event.data as { type?: string; id?: string; nome?: string | null; signedAt?: string | null };
       if (data?.type === "inspection-signed" && data.id) {
-        setItems(prev =>
-          prev.map(item =>
+        setItems(prev => {
+          const changedItem = prev.find(item => item.id === data.id && !item.signed);
+          if (changedItem) {
+            setStats(current => ({
+              ...current,
+              signed: current.signed + 1,
+              pending: Math.max(current.pending - 1, 0),
+            }));
+          }
+
+          return prev.map(item =>
             item.id === data.id
               ? {
                   ...item,
@@ -181,8 +263,8 @@ export default function AdminInspectionsPage() {
                   pcmNome: data.nome ?? item.pcmNome,
                 }
               : item
-          )
-        );
+          );
+        });
       }
     };
     channel.addEventListener("message", handler);
@@ -236,16 +318,8 @@ export default function AdminInspectionsPage() {
     return items.filter(item => selectedSet.has(item.maintainerKey));
   }, [items, selectedMaintainers]);
 
-  const visibleItems = useMemo(
-    () => (visibleCount === 0 ? [] : filteredItems.slice(0, visibleCount)),
-    [filteredItems, visibleCount]
-  );
-
-  const hasMore = visibleCount > 0 && filteredItems.length > visibleItems.length;
-
-  const handleLoadMore = useCallback(() => {
-    setVisibleCount(prev => (prev === 0 ? 10 : prev + 10));
-  }, []);
+  const visibleItems = filteredItems;
+  const hasMore = hasMoreItems;
 
   const toggleMaintainer = useCallback((maintainerId: string) => {
     setSelectedMaintainers(prev => {
@@ -281,7 +355,18 @@ export default function AdminInspectionsPage() {
           throw new Error(payload?.error || "Falha ao excluir inspeção");
         }
 
-        setItems(prev => prev.filter(item => item.id !== inspectionId));
+        setItems(prev => {
+          const deletedItem = prev.find(item => item.id === inspectionId);
+          if (deletedItem) {
+            setStats(current => ({
+              total: Math.max(current.total - 1, 0),
+              signed: deletedItem.signed ? Math.max(current.signed - 1, 0) : current.signed,
+              pending: deletedItem.signed ? current.pending : Math.max(current.pending - 1, 0),
+              withNc: deletedItem.hasNc ? Math.max(current.withNc - 1, 0) : current.withNc,
+            }));
+          }
+          return prev.filter(item => item.id !== inspectionId);
+        });
         setActionFeedback({ type: "success", message: "Inspeção excluída com sucesso." });
       } catch (err) {
         const message = err instanceof Error && err.message ? err.message : "Erro ao excluir inspeção";
@@ -293,9 +378,9 @@ export default function AdminInspectionsPage() {
     []
   );
 
-  const signedCount = useMemo(() => items.filter(item => item.signed).length, [items]);
-  const pendingCount = useMemo(() => items.filter(item => !item.signed).length, [items]);
-  const withNcCount = useMemo(() => items.filter(item => item.hasNc).length, [items]);
+  const signedCount = stats.signed;
+  const pendingCount = stats.pending;
+  const withNcCount = stats.withNc;
 
   return (
     <div className="max-w-7xl mx-auto space-y-6 p-6">
@@ -336,7 +421,7 @@ export default function AdminInspectionsPage() {
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
             <div className="flex flex-wrap items-baseline gap-2">
-              <span className="text-2xl font-semibold text-[var(--text)]">{items.length}</span>
+              <span className="text-2xl font-semibold text-[var(--text)]">{stats.total}</span>
               <Badge variant="muted">Registros</Badge>
               {withNcCount > 0 ? <Badge variant="warning">{withNcCount} com NC</Badge> : null}
             </div>
@@ -594,11 +679,11 @@ export default function AdminInspectionsPage() {
           {!loading && filteredItems.length > 0 ? (
             <div className="mt-6 flex items-center justify-between text-sm text-[var(--muted)]">
               <span>
-                Mostrando {visibleItems.length} de {filteredItems.length} inspeções selecionadas.
+                Mostrando {visibleItems.length} inspeções carregadas para os filtros selecionados.
               </span>
               {hasMore ? (
-                <Button type="button" variant="outline" size="sm" onClick={handleLoadMore}>
-                  Carregar mais
+                <Button type="button" variant="outline" size="sm" onClick={handleLoadMore} disabled={loadingMore} loading={loadingMore}>
+                  Carregar mais 20 inspeções
                 </Button>
               ) : null}
             </div>

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import {
   collection,
   deleteField,
   doc,
-  getDoc,
   getDocs,
+  limit,
+  orderBy,
   query,
+  startAfter,
   updateDoc,
   where,
+  type DocumentData,
+  type QueryDocumentSnapshot,
 } from "firebase/firestore";
 import { firebaseDb } from "@/lib/firebase-client";
 import { Button } from "@/components/ui/button";
@@ -50,6 +54,13 @@ interface TemplateMeta {
   nome?: string | null;
   versao?: string | null;
   itensMap: Map<string, TemplateItemData>;
+}
+
+interface TemplateCacheRecord {
+  id: string;
+  nome: string | null;
+  versao: string | null;
+  itens: TemplateItemData[];
 }
 
 interface NonConformityItem {
@@ -248,6 +259,40 @@ function renderStatusBadge(status: NonConformityStatus) {
   return <Badge variant="danger">Aberta</Badge>;
 }
 
+
+const PAGE_SIZE = 20;
+const FIRESTORE_IN_QUERY_LIMIT = 30;
+const MACHINES_SESSION_CACHE_KEY = "admin-nc-machines-v1";
+const TEMPLATES_SESSION_CACHE_KEY = "admin-nc-templates-v1";
+type IssueCursor = QueryDocumentSnapshot<DocumentData>;
+
+
+function readSessionCache<T>(key: string): T[] | null {
+  if (typeof window === "undefined") return null;
+  const cached = window.sessionStorage.getItem(key);
+  if (!cached) return null;
+  try {
+    const parsed = JSON.parse(cached);
+    return Array.isArray(parsed) ? (parsed as T[]) : null;
+  } catch {
+    window.sessionStorage.removeItem(key);
+    return null;
+  }
+}
+
+function writeSessionCache<T>(key: string, records: T[]) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(key, JSON.stringify(records));
+}
+
+function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
 const STATUS_OPTIONS: Array<{ value: NonConformityStatus; label: string }> = [
   { value: "open", label: "Aberta" },
   { value: "in_progress", label: "Em andamento" },
@@ -271,6 +316,9 @@ export default function AdminNonConformitiesPage() {
   const [expandedResolutions, setExpandedResolutions] = useState<Set<string>>(new Set());
   const [deleteDialogItem, setDeleteDialogItem] = useState<NonConformityItem | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMoreItems, setHasMoreItems] = useState(false);
+  const lastIssueCursorRef = useRef<IssueCursor | null>(null);
 
   const shouldRefreshOnFilterChange = Boolean(maintainerFilter || statusFilter !== "open" || dueDateFilter !== "default");
 
@@ -278,25 +326,41 @@ export default function AdminNonConformitiesPage() {
     setSelectedIds(prev => prev.filter(id => items.some(item => item.id === id)));
   }, [items]);
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
+  const loadData = useCallback(async (mode: "reset" | "append" = "reset") => {
+    const shouldAppend = mode === "append";
+    const cursor = lastIssueCursorRef.current;
+    if (shouldAppend && !cursor) return;
+
+    if (shouldAppend) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+      lastIssueCursorRef.current = null;
+      setHasMoreItems(false);
+    }
     setError(null);
     try {
-      const session = await fetch("/api/admin-session", { cache: "no-store" });
-      if (session.status === 401) {
-        window.location.href = "/admin/login";
-        return;
+      if (!shouldAppend) {
+        const session = await fetch("/api/admin-session", { cache: "no-store" });
+        if (session.status === 401) {
+          window.location.href = "/admin/login";
+          return;
+        }
       }
 
-      const issueConstraints = [where("status", "in", ["aberta", "concluida", "resolvida"])] as const;
+      const cachedMachines = readSessionCache<MachineOption>(MACHINES_SESSION_CACHE_KEY);
+      const cachedTemplates = readSessionCache<TemplateCacheRecord>(TEMPLATES_SESSION_CACHE_KEY);
+      const issueConstraints = cursor && shouldAppend
+        ? [where("status", "in", ["aberta", "concluida", "resolvida"]), orderBy("updatedAt", "desc"), startAfter(cursor), limit(PAGE_SIZE)]
+        : [where("status", "in", ["aberta", "concluida", "resolvida"]), orderBy("updatedAt", "desc"), limit(PAGE_SIZE)];
 
       const [machinesSnap, templatesSnap, issuesSnap] = await Promise.all([
-        getDocs(collection(firebaseDb, "machines")),
-        getDocs(collection(firebaseDb, "templates")),
+        cachedMachines ? Promise.resolve(null) : getDocs(collection(firebaseDb, "machines")),
+        cachedTemplates ? Promise.resolve(null) : getDocs(collection(firebaseDb, "templates")),
         getDocs(query(collection(firebaseDb, "issues"), ...issueConstraints)),
       ]);
 
-      const machineOptions: MachineOption[] = machinesSnap.docs.map(docSnap => {
+      const machineOptions: MachineOption[] = cachedMachines ?? machinesSnap!.docs.map(docSnap => {
         const data = docSnap.data() ?? {};
         return {
           id: docSnap.id,
@@ -306,21 +370,31 @@ export default function AdminNonConformitiesPage() {
           ativo: data.ativo !== false,
         } satisfies MachineOption;
       });
+      if (!cachedMachines) writeSessionCache(MACHINES_SESSION_CACHE_KEY, machineOptions);
       const machinesById = new Map(machineOptions.map(machine => [machine.id, machine]));
 
-      const templateMap = new Map<string, TemplateMeta>();
-      templatesSnap.docs.forEach(docSnap => {
+      const templateRecords: TemplateCacheRecord[] = cachedTemplates ?? templatesSnap!.docs.map(docSnap => {
         const data = docSnap.data() ?? {};
-        const itens = Array.isArray(data.itens) ? (data.itens as TemplateItemData[]) : [];
+        return {
+          id: docSnap.id,
+          nome: data.nome ? String(data.nome) : docSnap.id,
+          versao: data.versao ? String(data.versao) : null,
+          itens: Array.isArray(data.itens) ? (data.itens as TemplateItemData[]) : [],
+        };
+      });
+      if (!cachedTemplates) writeSessionCache(TEMPLATES_SESSION_CACHE_KEY, templateRecords);
+
+      const templateMap = new Map<string, TemplateMeta>();
+      templateRecords.forEach(template => {
         const itensMap = new Map<string, TemplateItemData>();
-        itens.forEach(item => {
+        template.itens.forEach(item => {
           if (item?.id) {
             itensMap.set(String(item.id), item);
           }
         });
-        templateMap.set(docSnap.id, {
-          nome: data.nome ? String(data.nome) : docSnap.id,
-          versao: data.versao ? String(data.versao) : null,
+        templateMap.set(template.id, {
+          nome: template.nome,
+          versao: template.versao,
           itensMap,
         });
       });
@@ -336,14 +410,15 @@ export default function AdminNonConformitiesPage() {
         )
       );
 
-      const sourceInspectionEntries = await Promise.all(
-        sourceInspectionIds.map(async inspectionId => {
-          const inspectionRef = doc(collection(firebaseDb, "inspecoes"), inspectionId);
-          const inspectionSnap = await getDoc(inspectionRef);
-          if (!inspectionSnap.exists()) {
-            return [inspectionId, null] as const;
-          }
+      const inspectionChunks = chunkArray(sourceInspectionIds, FIRESTORE_IN_QUERY_LIMIT);
+      const inspectionChunkSnaps = await Promise.all(
+        inspectionChunks.map(chunk =>
+          getDocs(query(collection(firebaseDb, "inspecoes"), where("__name__", "in", chunk)))
+        )
+      );
 
+      const sourceInspectionEntries = inspectionChunkSnaps.flatMap(chunkSnap =>
+        chunkSnap.docs.map(inspectionSnap => {
           const inspectionData = inspectionSnap.data() ?? {};
           const machine = (inspectionData.machine ?? {}) as Record<string, unknown>;
           const maintainer = (inspectionData.maintainer ?? {}) as Record<string, unknown>;
@@ -368,7 +443,7 @@ export default function AdminNonConformitiesPage() {
           });
 
           return [
-            inspectionId,
+            inspectionSnap.id,
             {
               machineId:
                 typeof machine.machineId === "string"
@@ -518,13 +593,22 @@ export default function AdminNonConformitiesPage() {
         });
       });
 
-      setTreatmentsByResponse(treatmentsRecord);
-      setItems(sortByLastActivityDesc(builtItems));
+      setTreatmentsByResponse(prev => (shouldAppend ? { ...prev, ...treatmentsRecord } : treatmentsRecord));
+      setItems(prev => {
+        const nextItems = shouldAppend ? [...prev, ...builtItems] : builtItems;
+        return sortByLastActivityDesc(nextItems);
+      });
+      lastIssueCursorRef.current = issuesSnap.docs.at(-1) ?? null;
+      setHasMoreItems(issuesSnap.docs.length === PAGE_SIZE);
     } catch (err: unknown) {
       const message = err instanceof Error && err.message ? err.message : "Erro ao carregar dados";
       setError(message);
     } finally {
-      setLoading(false);
+      if (shouldAppend) {
+        setLoadingMore(false);
+      } else {
+        setLoading(false);
+      }
     }
   }, []);
 
@@ -787,7 +871,7 @@ export default function AdminNonConformitiesPage() {
   const allVisibleSelected =
     filteredItems.length > 0 && filteredItems.every(item => selectedIds.includes(item.id));
   const selectedCount = selectedIds.length;
-  const canLoadMoreInitialItems = false;
+  const canLoadMoreInitialItems = hasMoreItems;
 
   if (loading) {
     return (
@@ -958,9 +1042,9 @@ export default function AdminNonConformitiesPage() {
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => loadData()}
-                disabled={loading}
-                loading={loading}
+                onClick={() => loadData("append")}
+                disabled={loadingMore}
+                loading={loadingMore}
               >
                 Carregar mais 20 NC
               </Button>
@@ -1181,9 +1265,9 @@ export default function AdminNonConformitiesPage() {
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => loadData()}
-                disabled={loading}
-                loading={loading}
+                onClick={() => loadData("append")}
+                disabled={loadingMore}
+                loading={loadingMore}
               >
                 Carregar mais 20 NC
               </Button>

--- a/src/lib/firebase-client.ts
+++ b/src/lib/firebase-client.ts
@@ -2,7 +2,7 @@
 import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getStorage } from "firebase/storage";
-import { getFirestore } from "firebase/firestore";
+import { initializeFirestore, persistentLocalCache, persistentMultipleTabManager } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY!,
@@ -17,4 +17,8 @@ const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 export const firebaseApp = app;
 export const firebaseAuth = getAuth(app);
 export const firebaseStorage = getStorage(app);
-export const firebaseDb = getFirestore(app);
+export const firebaseDb = initializeFirestore(app, {
+  localCache: persistentLocalCache({
+    tabManager: persistentMultipleTabManager(),
+  }),
+});


### PR DESCRIPTION
### Motivation

- Reduce repeated Firestore reads and speed up admin pages by caching static lookups (machines/templates) in sessionStorage.
- Improve scalability of large lists by adding server-side pagination for inspections and non-conformities.
- Provide accurate overview metrics for inspections (total, signed, pending, with NC) to avoid expensive client-side computation.
- Make Firestore client use a persistent local cache with multi-tab support to improve offline/parallel-tab UX.

### Description

- Initialized Firestore with `initializeFirestore` and `persistentLocalCache` with `persistentMultipleTabManager` in `src/lib/firebase-client.ts`.
- Added session cache helpers `readSessionCache`/`writeSessionCache` and cache keys to store machines and templates in `admin/checklists/page.tsx` and `admin/nc/page.tsx`, and wired reads/writes to avoid redundant `getDocs` calls.
- Implemented pagination for inspections in `admin/inspecoes/page.tsx` using `limit`, `startAfter`, and `getCountFromServer` to fetch `PAGE_SIZE` pages and load stats (`total`, `signed`, `pending`, `withNc`), plus `fetchInspectionPage` and `handleLoadMore` flows and UI changes for "Carregar mais".
- Added `mapInspectionDoc` helper to normalize inspection documents and updated BroadcastChannel handling and deletion flow to keep stats consistent when inspections are signed or deleted.
- Updated non-conformities page (`admin/nc/page.tsx`) to support paginated issue queries, chunked `where('__name__', 'in', ...)` lookup via `chunkArray` (respecting Firestore `in` limits), caching for machines/templates, and append/reset loading modes with `lastIssueCursorRef`.
- Minor UI and text changes to reflect pagination sizes and counts, and adjusted component state and types to support new flows and cursor-based paging.

### Testing

- Performed a local TypeScript/Next build via `pnpm build` to validate types and bundling, which completed successfully.
- Ran linting with `pnpm lint` and local dev smoke checks (loading admin pages, pagination and cache flows) with no automated failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58e7a110c483308667a30898be986c)