### PR TITLE
Add maintainer filtering, inspection return API and transfer of scheduled inspections; caching and Firestore index hint

### DIFF
--- a/src/app/admin/inspecoes/assinar/page.tsx
+++ b/src/app/admin/inspecoes/assinar/page.tsx
@@ -375,6 +375,24 @@ function SignatureModal({
                 </label>
               ) : null}
             </div>
+            <div className="flex flex-col gap-3 rounded-lg border border-[var(--border)] bg-[var(--surface)] p-3 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-xs text-[var(--muted)]">
+                Confira a assinatura acima e confirme sem precisar rolar pelos itens avaliados.
+              </p>
+              <div className="flex flex-wrap justify-end gap-3">
+                <Button type="button" variant="ghost" onClick={onClose} disabled={loading}>
+                  Cancelar
+                </Button>
+                <Button
+                  type="button"
+                  onClick={onConfirm}
+                  loading={loading}
+                  disabled={loading || detailLoading}
+                >
+                  Confirmar assinatura
+                </Button>
+              </div>
+            </div>
             {error && <p className="text-sm text-[var(--danger)]">{error}</p>}
           </section>
 
@@ -467,19 +485,6 @@ function SignatureModal({
 
 
 
-          <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
-            <Button type="button" variant="ghost" onClick={onClose} disabled={loading}>
-              Cancelar
-            </Button>
-            <Button
-              type="button"
-              onClick={onConfirm}
-              loading={loading}
-              disabled={loading || detailLoading}
-            >
-              Confirmar assinatura
-            </Button>
-          </div>
         </div>
       </div>
     </div>,

--- a/src/app/admin/inspecoes/assinar/page.tsx
+++ b/src/app/admin/inspecoes/assinar/page.tsx
@@ -251,93 +251,6 @@ function SignatureModal({
                   </div>
                 </div>
 
-                <div className="space-y-3">
-                  <div className="flex items-center justify-between">
-                    <h4 className="text-sm font-semibold text-[var(--text)]">Itens avaliados</h4>
-                    <Badge variant={inspectionInfo.qtdNC && inspectionInfo.qtdNC > 0 ? "danger" : "success"}>
-                      {inspectionInfo.qtdNC && inspectionInfo.qtdNC > 0
-                        ? `${inspectionInfo.qtdNC} NC`
-                        : "Sem NC"}
-                    </Badge>
-                  </div>
-                  {normalizedAnswers.length === 0 ? (
-                    <EmptyState
-                      title="Sem itens registrados"
-                      description="Não foi possível localizar as respostas desta inspeção."
-                      className="py-10"
-                    />
-                  ) : (
-                    <div className="space-y-3">
-                      {normalizedAnswers.map(answer => (
-                        <div
-                          key={answer.questionId}
-                          className={cn(
-                            "rounded-lg border p-4",
-                            answer.response === "nc"
-                              ? "border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_92%)]"
-                              : "border-[var(--border)] bg-white"
-                          )}
-                        >
-                          <div className="flex flex-wrap items-center justify-between gap-3">
-                            <p className="text-sm font-medium text-[var(--text)]">
-                              {answer.questionText ?? `Item ${answer.questionId}`}
-                            </p>
-                            <Badge variant={responseBadgeVariant[answer.response]}>
-                              {responseLabels[answer.response]}
-                            </Badge>
-                          </div>
-                          {answer.recurrence ? (
-                            <div className="mt-2">
-                              <Badge variant="warning">Reincidência</Badge>
-                            </div>
-                          ) : null}
-                          {answer.observation?.trim() ? (
-                            <p className="mt-2 text-sm text-[var(--text)]">
-                              <span className="font-medium text-[var(--muted)]">Observação:</span> {answer.observation}
-                            </p>
-                          ) : null}
-                          {answer.itemOsNumero?.trim() ? (
-                            <p className="text-xs text-[var(--muted)]">
-                              Nº da O.S. do item: <span className="font-medium text-[var(--text)]">{answer.itemOsNumero}</span>
-                            </p>
-                          ) : null}
-                          {answer.photoUrls && answer.photoUrls.length > 0 ? (
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              {answer.photoUrls.map((photo, index) => (
-                                <a
-                                  key={`${answer.questionId}-photo-${index}`}
-                                  href={photo.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="group overflow-hidden rounded-md border focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
-                                >
-                                  <Image
-                                    src={photo.url}
-                                    alt={`Foto da inspeção - item ${answer.questionId}`}
-                                    width={160}
-                                    height={120}
-                                    className="h-24 w-40 object-cover transition-transform duration-200 group-hover:scale-105"
-                                    unoptimized
-                                  />
-                                </a>
-                              ))}
-                            </div>
-                          ) : null}
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </div>
-            ) : (
-              <EmptyState
-                title="Inspeção não encontrada"
-                description="Não foi possível carregar os detalhes desta inspeção."
-                className="py-10"
-              />
-            )}
-          </section>
-
           <section className="space-y-4">
             <h3 className="text-base font-semibold text-[var(--text)]">Assinatura do PCM</h3>
             <div className="grid gap-4 md:grid-cols-2">
@@ -464,6 +377,95 @@ function SignatureModal({
             </div>
             {error && <p className="text-sm text-[var(--danger)]">{error}</p>}
           </section>
+
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h4 className="text-sm font-semibold text-[var(--text)]">Itens avaliados</h4>
+                    <Badge variant={inspectionInfo.qtdNC && inspectionInfo.qtdNC > 0 ? "danger" : "success"}>
+                      {inspectionInfo.qtdNC && inspectionInfo.qtdNC > 0
+                        ? `${inspectionInfo.qtdNC} NC`
+                        : "Sem NC"}
+                    </Badge>
+                  </div>
+                  {normalizedAnswers.length === 0 ? (
+                    <EmptyState
+                      title="Sem itens registrados"
+                      description="Não foi possível localizar as respostas desta inspeção."
+                      className="py-10"
+                    />
+                  ) : (
+                    <div className="space-y-3">
+                      {normalizedAnswers.map(answer => (
+                        <div
+                          key={answer.questionId}
+                          className={cn(
+                            "rounded-lg border p-4",
+                            answer.response === "nc"
+                              ? "border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_92%)]"
+                              : "border-[var(--border)] bg-white"
+                          )}
+                        >
+                          <div className="flex flex-wrap items-center justify-between gap-3">
+                            <p className="text-sm font-medium text-[var(--text)]">
+                              {answer.questionText ?? `Item ${answer.questionId}`}
+                            </p>
+                            <Badge variant={responseBadgeVariant[answer.response]}>
+                              {responseLabels[answer.response]}
+                            </Badge>
+                          </div>
+                          {answer.recurrence ? (
+                            <div className="mt-2">
+                              <Badge variant="warning">Reincidência</Badge>
+                            </div>
+                          ) : null}
+                          {answer.observation?.trim() ? (
+                            <p className="mt-2 text-sm text-[var(--text)]">
+                              <span className="font-medium text-[var(--muted)]">Observação:</span> {answer.observation}
+                            </p>
+                          ) : null}
+                          {answer.itemOsNumero?.trim() ? (
+                            <p className="text-xs text-[var(--muted)]">
+                              Nº da O.S. do item: <span className="font-medium text-[var(--text)]">{answer.itemOsNumero}</span>
+                            </p>
+                          ) : null}
+                          {answer.photoUrls && answer.photoUrls.length > 0 ? (
+                            <div className="mt-3 flex flex-wrap gap-2">
+                              {answer.photoUrls.map((photo, index) => (
+                                <a
+                                  key={`${answer.questionId}-photo-${index}`}
+                                  href={photo.url}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="group overflow-hidden rounded-md border focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+                                >
+                                  <Image
+                                    src={photo.url}
+                                    alt={`Foto da inspeção - item ${answer.questionId}`}
+                                    width={160}
+                                    height={120}
+                                    className="h-24 w-40 object-cover transition-transform duration-200 group-hover:scale-105"
+                                    unoptimized
+                                  />
+                                </a>
+                              ))}
+                            </div>
+                          ) : null}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <EmptyState
+                title="Inspeção não encontrada"
+                description="Não foi possível carregar os detalhes desta inspeção."
+                className="py-10"
+              />
+            )}
+          </section>
+
+
 
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
             <Button type="button" variant="ghost" onClick={onClose} disabled={loading}>

--- a/src/app/admin/inspecoes/page.tsx
+++ b/src/app/admin/inspecoes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import {
   collection,
@@ -20,6 +20,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
   Table,
   TableBody,
@@ -51,6 +52,13 @@ interface InspectionListItem {
 }
 
 
+interface MaintainerOption {
+  id: string;
+  nome: string | null;
+  matricula: string | null;
+  ativo?: boolean;
+}
+
 interface InspectionStats {
   total: number;
   signed: number;
@@ -59,6 +67,7 @@ interface InspectionStats {
 }
 
 const PAGE_SIZE = 20;
+const MAINTAINERS_SESSION_CACHE_KEY = "admin-inspecoes-maintainers-v1";
 type InspectionCursor = QueryDocumentSnapshot<DocumentData>;
 
 const emptyStats: InspectionStats = {
@@ -67,6 +76,47 @@ const emptyStats: InspectionStats = {
   pending: 0,
   withNc: 0,
 };
+
+function readSessionCache<T>(key: string): T[] | null {
+  if (typeof window === "undefined") return null;
+  const cached = window.sessionStorage.getItem(key);
+  if (!cached) return null;
+  try {
+    const parsed = JSON.parse(cached);
+    return Array.isArray(parsed) ? (parsed as T[]) : null;
+  } catch {
+    window.sessionStorage.removeItem(key);
+    return null;
+  }
+}
+
+function writeSessionCache<T>(key: string, records: T[]) {
+  if (typeof window === "undefined") return;
+  window.sessionStorage.setItem(key, JSON.stringify(records));
+}
+
+function extractFirebaseIndexUrl(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  const match = message.match(/https:\/\/console\.firebase\.google\.com\/[^\s)]+/);
+  return match?.[0] ?? null;
+}
+
+async function loadMaintainers(): Promise<MaintainerOption[]> {
+  const cached = readSessionCache<MaintainerOption>(MAINTAINERS_SESSION_CACHE_KEY);
+  if (cached) return cached;
+  const snap = await getDocs(collection(firebaseDb, "mantenedores"));
+  const records = snap.docs.map(docSnap => {
+    const data = docSnap.data() ?? {};
+    return {
+      id: docSnap.id,
+      nome: typeof data.nome === "string" ? data.nome : null,
+      matricula: typeof data.matricula === "string" ? data.matricula.toUpperCase() : null,
+      ativo: data.ativo !== false,
+    } satisfies MaintainerOption;
+  }).sort((a, b) => (a.nome ?? a.matricula ?? a.id).localeCompare(b.nome ?? b.matricula ?? b.id, "pt-BR"));
+  writeSessionCache(MAINTAINERS_SESSION_CACHE_KEY, records);
+  return records;
+}
 
 async function loadInspectionStats(): Promise<InspectionStats> {
   const inspectionsRef = collection(firebaseDb, "inspecoes");
@@ -170,14 +220,18 @@ export default function AdminInspectionsPage() {
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<InspectionListItem[]>([]);
   const [stats, setStats] = useState<InspectionStats>(emptyStats);
-  const [selectedMaintainers, setSelectedMaintainers] = useState<string[]>([]);
+  const [maintainers, setMaintainers] = useState<MaintainerOption[]>([]);
+  const [selectedMaintainerId, setSelectedMaintainerId] = useState<string | null>(null);
+  const [indexUrl, setIndexUrl] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMoreItems, setHasMoreItems] = useState(false);
   const lastInspectionCursorRef = useRef<InspectionCursor | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [returningId, setReturningId] = useState<string | null>(null);
+  const [returnDialogItem, setReturnDialogItem] = useState<InspectionListItem | null>(null);
   const [actionFeedback, setActionFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
 
-  const fetchInspectionPage = useCallback(async (mode: "reset" | "append" = "reset") => {
+  const fetchInspectionPage = useCallback(async (maintainerId: string, mode: "reset" | "append" = "reset") => {
     const shouldAppend = mode === "append";
     const cursor = lastInspectionCursorRef.current;
     if (shouldAppend && !cursor) return;
@@ -188,9 +242,11 @@ export default function AdminInspectionsPage() {
       setLoading(true);
       lastInspectionCursorRef.current = null;
       setHasMoreItems(false);
+      setItems([]);
       setActionFeedback(null);
     }
     setError(null);
+    setIndexUrl(null);
 
     try {
       if (!shouldAppend) {
@@ -201,9 +257,11 @@ export default function AdminInspectionsPage() {
         }
       }
 
-      const inspectionsQuery = cursor && shouldAppend
-        ? query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"), startAfter(cursor), limit(PAGE_SIZE))
-        : query(collection(firebaseDb, "inspecoes"), orderBy("createdAt", "desc"), limit(PAGE_SIZE));
+      const constraints = [where("maintainer.id", "==", maintainerId), orderBy("createdAt", "desc")];
+      const inspectionsQuery = query(
+        collection(firebaseDb, "inspecoes"),
+        ...(shouldAppend && cursor ? [...constraints, startAfter(cursor), limit(PAGE_SIZE)] : [...constraints, limit(PAGE_SIZE)])
+      );
 
       const [inspectionsSnap, inspectionStats] = await Promise.all([
         getDocs(inspectionsQuery),
@@ -212,29 +270,58 @@ export default function AdminInspectionsPage() {
 
       const mapped = inspectionsSnap.docs.map(mapInspectionDoc);
       setItems(prev => (shouldAppend ? [...prev, ...mapped] : mapped));
-      if (inspectionStats) {
-        setStats(inspectionStats);
-      }
+      if (inspectionStats) setStats(inspectionStats);
       lastInspectionCursorRef.current = inspectionsSnap.docs.at(-1) ?? null;
       setHasMoreItems(inspectionsSnap.docs.length === PAGE_SIZE);
     } catch (err: unknown) {
+      const indexLink = extractFirebaseIndexUrl(err);
+      if (indexLink) setIndexUrl(indexLink);
       const message = err instanceof Error && err.message ? err.message : "Erro ao carregar inspeções";
-      setError(message);
+      setError(indexLink ? "O Firestore exige um índice composto para esta consulta." : message);
     } finally {
-      if (shouldAppend) {
-        setLoadingMore(false);
-      } else {
-        setLoading(false);
-      }
+      if (shouldAppend) setLoadingMore(false);
+      else setLoading(false);
     }
   }, []);
 
-  const loadData = useCallback(() => fetchInspectionPage("reset"), [fetchInspectionPage]);
-  const handleLoadMore = useCallback(() => fetchInspectionPage("append"), [fetchInspectionPage]);
+  const loadData = useCallback(() => {
+    if (selectedMaintainerId) {
+      fetchInspectionPage(selectedMaintainerId, "reset");
+      return;
+    }
+    setItems([]);
+    setLoading(false);
+  }, [fetchInspectionPage, selectedMaintainerId]);
+  const handleLoadMore = useCallback(() => {
+    if (selectedMaintainerId) fetchInspectionPage(selectedMaintainerId, "append");
+  }, [fetchInspectionPage, selectedMaintainerId]);
 
   useEffect(() => {
-    loadData();
-  }, [loadData]);
+    let mounted = true;
+    async function initialize() {
+      setLoading(true);
+      setError(null);
+      try {
+        const session = await fetch("/api/admin-session", { cache: "no-store" });
+        if (session.status === 401) {
+          window.location.href = "/admin/login";
+          return;
+        }
+        const [maintainerRecords, inspectionStats] = await Promise.all([loadMaintainers(), loadInspectionStats()]);
+        if (!mounted) return;
+        setMaintainers(maintainerRecords);
+        setStats(inspectionStats);
+      } catch (err) {
+        if (!mounted) return;
+        const message = err instanceof Error && err.message ? err.message : "Erro ao carregar mantenedores";
+        setError(message);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+    initialize();
+    return () => { mounted = false; };
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined" || !("BroadcastChannel" in window)) {
@@ -274,65 +361,47 @@ export default function AdminInspectionsPage() {
     };
   }, []);
 
-  useEffect(() => {
-    setSelectedMaintainers(prev => {
-      if (prev.length === 0) return prev;
-      const validMaintainers = new Set(items.map(item => item.maintainerKey));
-      const filtered = prev.filter(id => validMaintainers.has(id));
-      return filtered.length === prev.length ? prev : filtered;
-    });
-  }, [items]);
-
-  const maintainerOptions = useMemo(() => {
-    const map = new Map<
-      string,
-      { id: string; nome: string | null; matricula: string | null; total: number }
-    >();
-
-    for (const item of items) {
-      const key = item.maintainerKey || "unknown";
-      const current = map.get(key) ?? {
-        id: key,
-        nome: item.maintainerNome,
-        matricula: item.maintainerMatricula,
-        total: 0,
-      };
-      current.nome = current.nome ?? item.maintainerNome;
-      current.matricula = current.matricula ?? item.maintainerMatricula;
-      current.total += 1;
-      map.set(key, current);
-    }
-
-    return Array.from(map.values()).sort((a, b) => {
-      const nameA = (a.nome ?? a.matricula ?? a.id).toLowerCase();
-      const nameB = (b.nome ?? b.matricula ?? b.id).toLowerCase();
-      return nameA.localeCompare(nameB, "pt-BR");
-    });
-  }, [items]);
-
-  const filteredItems = useMemo(() => {
-    if (selectedMaintainers.length === 0) {
-      return [];
-    }
-    const selectedSet = new Set(selectedMaintainers);
-    return items.filter(item => selectedSet.has(item.maintainerKey));
-  }, [items, selectedMaintainers]);
-
-  const visibleItems = filteredItems;
+  const maintainerOptions = maintainers;
+  const visibleItems = items;
   const hasMore = hasMoreItems;
 
-  const toggleMaintainer = useCallback((maintainerId: string) => {
-    setSelectedMaintainers(prev => {
-      if (prev.includes(maintainerId)) {
-        return prev.filter(id => id !== maintainerId);
-      }
-      return [...prev, maintainerId];
-    });
-  }, []);
+  const selectMaintainer = useCallback((maintainerId: string) => {
+    setSelectedMaintainerId(maintainerId);
+    fetchInspectionPage(maintainerId, "reset");
+  }, [fetchInspectionPage]);
 
   const clearMaintainers = useCallback(() => {
-    setSelectedMaintainers([]);
+    setSelectedMaintainerId(null);
+    setItems([]);
+    lastInspectionCursorRef.current = null;
+    setHasMoreItems(false);
+    setIndexUrl(null);
+    setError(null);
   }, []);
+
+
+  const handleReturnInspection = useCallback(async () => {
+    if (!returnDialogItem) return;
+
+    setReturningId(returnDialogItem.id);
+    setActionFeedback(null);
+    try {
+      const response = await fetch(`/api/inspecoes/${returnDialogItem.id}/return`, { method: "PATCH" });
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(payload?.error || "Falha ao devolver inspeção");
+      }
+
+      setItems(prev => prev.filter(item => item.id !== returnDialogItem.id));
+      setActionFeedback({ type: "success", message: "Inspeção devolvida ao mantenedor como rascunho." });
+      setReturnDialogItem(null);
+    } catch (err: unknown) {
+      const message = err instanceof Error && err.message ? err.message : "Erro ao devolver inspeção";
+      setActionFeedback({ type: "error", message });
+    } finally {
+      setReturningId(null);
+    }
+  }, [returnDialogItem]);
 
   const handleDeleteInspection = useCallback(
     async (inspectionId: string) => {
@@ -393,7 +462,8 @@ export default function AdminInspectionsPage() {
 
       {error ? (
         <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_85%)] px-4 py-3 text-[var(--danger)]">
-          {error}
+          <p>{error}</p>
+          {indexUrl ? <a className="underline" href={indexUrl} target="_blank" rel="noreferrer">Criar índice composto no Firebase</a> : null}
         </div>
       ) : null}
 
@@ -470,7 +540,7 @@ export default function AdminInspectionsPage() {
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium text-[var(--text)]">Filtrar por mantenedor</span>
               <p className="text-xs text-[var(--muted)]">
-                Selecione um ou mais mantenedores para visualizar apenas suas inspeções recentes.
+                Selecione um mantenedor para buscar no Firestore as últimas 20 inspeções vinculadas a ele.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -479,19 +549,19 @@ export default function AdminInspectionsPage() {
                 size="sm"
                 variant="ghost"
                 onClick={clearMaintainers}
-                disabled={selectedMaintainers.length === 0}
+                disabled={!selectedMaintainerId}
               >
                 Limpar seleção
               </Button>
             </div>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {maintainerOptions.map(option => {
-                const isActive = selectedMaintainers.includes(option.id);
+                const isActive = selectedMaintainerId === option.id;
                 return (
                   <button
                     key={option.id}
                     type="button"
-                    onClick={() => toggleMaintainer(option.id)}
+                    onClick={() => selectMaintainer(option.id)}
                     className={cn(
                       buttonStyles({ variant: "ghost", size: "lg" }),
                       "group flex h-full min-h-[120px] w-full flex-col items-stretch justify-between gap-4 rounded-3xl border px-4 py-5 text-left",
@@ -529,13 +599,13 @@ export default function AdminInspectionsPage() {
                           : "bg-[rgba(37,99,235,0.08)] text-[color-mix(in_oklab,#1d4ed8,#0f172a_35%)]"
                       )}
                     >
-                      {option.total} inspeções
+                      Ver histórico
                     </span>
                   </button>
                 );
               })}
             </div>
-            {selectedMaintainers.length === 0 ? (
+            {!selectedMaintainerId ? (
               <p className="text-xs text-[var(--muted)]">Selecione um mantenedor para carregar suas inspeções.</p>
             ) : null}
           </div>
@@ -552,10 +622,10 @@ export default function AdminInspectionsPage() {
             </div>
           ) : null}
 
-          {selectedMaintainers.length === 0 ? (
+          {!selectedMaintainerId ? (
             <EmptyState
-              title="Selecione mantenedores"
-              description="Escolha pelo menos um mantenedor para visualizar as inspeções correspondentes."
+              title="Selecione um mantenedor"
+              description="Selecione um mantenedor acima para carregar o histórico de inspeções"
               className="py-12"
             />
           ) : loading ? (
@@ -567,7 +637,7 @@ export default function AdminInspectionsPage() {
                 </div>
               ))}
             </div>
-          ) : filteredItems.length === 0 ? (
+          ) : visibleItems.length === 0 ? (
             <EmptyState
               title="Nenhuma inspeção encontrada"
               description="Não há inspeções registradas para os mantenedores selecionados."
@@ -646,6 +716,16 @@ export default function AdminInspectionsPage() {
                             Assinar
                           </Link>
                         ) : null}
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100"
+                          onClick={() => setReturnDialogItem(item)}
+                          loading={returningId === item.id}
+                        >
+                          ↩ Devolver
+                        </Button>
                         <Link
                           href={`/admin/inspecoes/${item.id}/edit`}
                           className={buttonStyles({ size: "sm", variant: "secondary" })}
@@ -676,10 +756,10 @@ export default function AdminInspectionsPage() {
               </TableBody>
             </Table>
           )}
-          {!loading && filteredItems.length > 0 ? (
+          {!loading && visibleItems.length > 0 ? (
             <div className="mt-6 flex items-center justify-between text-sm text-[var(--muted)]">
               <span>
-                Mostrando {visibleItems.length} inspeções carregadas para os filtros selecionados.
+                Mostrando {visibleItems.length} inspeções carregadas para o mantenedor selecionado.
               </span>
               {hasMore ? (
                 <Button type="button" variant="outline" size="sm" onClick={handleLoadMore} disabled={loadingMore} loading={loadingMore}>
@@ -690,6 +770,20 @@ export default function AdminInspectionsPage() {
           ) : null}
         </CardContent>
       </Card>
+
+      <ConfirmDialog
+        open={Boolean(returnDialogItem)}
+        title="Devolver inspeção"
+        description="Deseja devolver esta inspeção para o mantenedor? Ela voltará como rascunho para que ele possa corrigir e reenviar."
+        confirmLabel="Devolver"
+        cancelLabel="Cancelar"
+        busy={returningId != null}
+        onCancel={() => {
+          if (returningId) return;
+          setReturnDialogItem(null);
+        }}
+        onConfirm={handleReturnInspection}
+      />
     </div>
   );
 }

--- a/src/app/admin/inspecoes/page.tsx
+++ b/src/app/admin/inspecoes/page.tsx
@@ -226,6 +226,7 @@ export default function AdminInspectionsPage() {
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMoreItems, setHasMoreItems] = useState(false);
   const lastInspectionCursorRef = useRef<InspectionCursor | null>(null);
+  const maintainerQueryFieldRef = useRef<"maintainer.maintId" | "maintainer.id">("maintainer.maintId");
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [returningId, setReturningId] = useState<string | null>(null);
   const [returnDialogItem, setReturnDialogItem] = useState<InspectionListItem | null>(null);
@@ -257,16 +258,26 @@ export default function AdminInspectionsPage() {
         }
       }
 
-      const constraints = [where("maintainer.id", "==", maintainerId), orderBy("createdAt", "desc")];
-      const inspectionsQuery = query(
-        collection(firebaseDb, "inspecoes"),
-        ...(shouldAppend && cursor ? [...constraints, startAfter(cursor), limit(PAGE_SIZE)] : [...constraints, limit(PAGE_SIZE)])
-      );
+      const buildInspectionQuery = (field: "maintainer.maintId" | "maintainer.id", pageCursor: InspectionCursor | null) => {
+        const constraints = [where(field, "==", maintainerId), orderBy("createdAt", "desc")];
+        return query(
+          collection(firebaseDb, "inspecoes"),
+          ...(shouldAppend && pageCursor ? [...constraints, startAfter(pageCursor), limit(PAGE_SIZE)] : [...constraints, limit(PAGE_SIZE)])
+        );
+      };
 
-      const [inspectionsSnap, inspectionStats] = await Promise.all([
-        getDocs(inspectionsQuery),
-        shouldAppend ? Promise.resolve(null) : loadInspectionStats(),
-      ]);
+      let activeField = shouldAppend ? maintainerQueryFieldRef.current : "maintainer.maintId" as const;
+      let inspectionsQuery = buildInspectionQuery(activeField, cursor);
+      const inspectionStatsPromise = shouldAppend ? Promise.resolve(null) : loadInspectionStats();
+      let inspectionsSnap = await getDocs(inspectionsQuery);
+
+      if (!shouldAppend && inspectionsSnap.empty) {
+        activeField = "maintainer.id";
+        inspectionsQuery = buildInspectionQuery(activeField, null);
+        inspectionsSnap = await getDocs(inspectionsQuery);
+      }
+      maintainerQueryFieldRef.current = activeField;
+      const inspectionStats = await inspectionStatsPromise;
 
       const mapped = inspectionsSnap.docs.map(mapInspectionDoc);
       setItems(prev => (shouldAppend ? [...prev, ...mapped] : mapped));

--- a/src/app/admin/mantenedores/page.tsx
+++ b/src/app/admin/mantenedores/page.tsx
@@ -2,14 +2,17 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { collection, getDocs, query, where, writeBatch } from "firebase/firestore";
 
 import { Button, buttonStyles } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { firebaseDb } from "@/lib/firebase-client";
 
 type Maintainer = {
   id: string;
@@ -20,6 +23,28 @@ type Maintainer = {
   ativo: boolean;
 };
 
+type TransferTarget = {
+  original: Maintainer;
+  substituteId: string;
+};
+
+function normalizeName(value: string | null | undefined) {
+  return (value ?? "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function chunkArray<T>(items: T[], chunkSize: number) {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
 export default function MantenedoresPage() {
   const [data, setData] = useState<Maintainer[]>([]);
   const [q, setQ] = useState("");
@@ -28,6 +53,8 @@ export default function MantenedoresPage() {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<Maintainer | null>(null);
+  const [transferTarget, setTransferTarget] = useState<TransferTarget | null>(null);
+  const [transferring, setTransferring] = useState(false);
 
   useEffect(() => {
     fetch("/api/admin-session", { cache: "no-store" }).then(r => {
@@ -50,6 +77,11 @@ export default function MantenedoresPage() {
         return m.matricula.toLowerCase().includes(term) || m.nome.toLowerCase().includes(term);
       }),
     [data, q]
+  );
+
+  const activeMaintainers = useMemo(
+    () => data.filter(maintainer => maintainer.ativo),
+    [data]
   );
 
   function handleOpenDelete(target: Maintainer) {
@@ -79,6 +111,110 @@ export default function MantenedoresPage() {
       setFeedback({ type: "error", message });
     } finally {
       setDeleting(false);
+    }
+  }
+
+
+  function handleOpenTransfer(original: Maintainer) {
+    const firstSubstitute = activeMaintainers.find(maintainer => maintainer.id !== original.id) ?? null;
+    setTransferTarget({ original, substituteId: firstSubstitute?.id ?? "" });
+    setFeedback(null);
+  }
+
+  async function handleTransferInspections() {
+    if (!transferTarget?.original || !transferTarget.substituteId) return;
+    const substitute = data.find(maintainer => maintainer.id === transferTarget.substituteId);
+    if (!substitute) {
+      setFeedback({ type: "error", message: "Selecione um mantenedor substituto válido." });
+      return;
+    }
+
+    setTransferring(true);
+    setFeedback(null);
+    try {
+      const programacoesRef = collection(firebaseDb, "programacoes_inspecao");
+      const [responsavelIdsSnap, maintainerIdSnap, responsavelPrincipalSnap] = await Promise.all([
+        getDocs(query(programacoesRef, where("status", "==", "PENDENTE"), where("responsavelIds", "array-contains", transferTarget.original.id))),
+        getDocs(query(programacoesRef, where("status", "==", "PENDENTE"), where("maintainerId", "==", transferTarget.original.id))),
+        getDocs(query(programacoesRef, where("status", "==", "PENDENTE"), where("responsavel.maintId", "==", transferTarget.original.id))),
+      ]);
+      const docsById = new Map([
+        ...responsavelIdsSnap.docs,
+        ...maintainerIdSnap.docs,
+        ...responsavelPrincipalSnap.docs,
+      ].map(docSnap => [docSnap.id, docSnap] as const));
+      const docs = Array.from(docsById.values());
+      const substituteNormalizedName = normalizeName(substitute.nome);
+
+      for (const docsChunk of chunkArray(docs, 450)) {
+        const batch = writeBatch(firebaseDb);
+        docsChunk.forEach(docSnap => {
+          const current = docSnap.data() ?? {};
+          const responsaveisRaw = Array.isArray(current.responsaveis) ? current.responsaveis : [];
+          const nextResponsaveis = responsaveisRaw.map(item => {
+            const maintId = typeof item?.maintId === "string" ? item.maintId : null;
+            if (maintId !== transferTarget.original.id) return item;
+            return {
+              ...item,
+              maintId: substitute.id,
+              nome: substitute.nome,
+              matricula: substitute.matricula,
+              origem: "transferencia_ferias",
+              transferidoDe: {
+                maintId: transferTarget.original.id,
+                nome: transferTarget.original.nome,
+                matricula: transferTarget.original.matricula,
+              },
+            };
+          });
+          const responsavelIds = Array.isArray(current.responsavelIds)
+            ? current.responsavelIds.filter((id): id is string => typeof id === "string" && id !== transferTarget.original.id)
+            : [];
+          const nextResponsavelIds = Array.from(new Set([...responsavelIds, substitute.id]));
+          const normalizedNames = Array.isArray(current.responsavelNomesNormalizados)
+            ? current.responsavelNomesNormalizados.filter((name): name is string => typeof name === "string" && name !== normalizeName(transferTarget.original.nome))
+            : [];
+          const nextNormalizedNames = Array.from(new Set([...normalizedNames, substituteNormalizedName].filter(Boolean)));
+
+          batch.update(docSnap.ref, {
+            responsavel: {
+              ...(typeof current.responsavel === "object" && current.responsavel ? current.responsavel : {}),
+              maintId: substitute.id,
+              nome: substitute.nome,
+              nomeNormalizado: substituteNormalizedName || null,
+              matricula: substitute.matricula,
+              origem: "transferencia_ferias",
+              transferidoDe: {
+                maintId: transferTarget.original.id,
+                nome: transferTarget.original.nome,
+                matricula: transferTarget.original.matricula,
+              },
+            },
+            responsaveis: nextResponsaveis.length > 0
+              ? nextResponsaveis
+              : [{ maintId: substitute.id, nome: substitute.nome, matricula: substitute.matricula, origem: "transferencia_ferias" }],
+            responsavelIds: nextResponsavelIds,
+            responsavelNomesNormalizados: nextNormalizedNames,
+            maintainerId: substitute.id,
+            maintainerNome: substitute.nome,
+            maintainerMatricula: substitute.matricula,
+            transferredFromMaintainerId: transferTarget.original.id,
+            transferredAt: new Date().toISOString(),
+          });
+        });
+        await batch.commit();
+      }
+
+      setFeedback({
+        type: "success",
+        message: `${docs.length} inspeções programadas foram transferidas com sucesso para ${substitute.nome}.`,
+      });
+      setTransferTarget(null);
+    } catch (error: unknown) {
+      const message = error instanceof Error && error.message ? error.message : "Erro ao transferir programações";
+      setFeedback({ type: "error", message });
+    } finally {
+      setTransferring(false);
     }
   }
 
@@ -200,6 +336,17 @@ export default function MantenedoresPage() {
                         </Link>
                         <Button
                           type="button"
+                          variant="outline"
+                          size="sm"
+                          className="border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100"
+                          onClick={() => handleOpenTransfer(m)}
+                          disabled={!m.ativo || activeMaintainers.length < 2}
+                        >
+                          <i className="fas fa-calendar-alt" aria-hidden />
+                          Transferir Inspeções
+                        </Button>
+                        <Button
+                          type="button"
                           variant="ghost"
                           size="sm"
                           className="text-rose-600 hover:bg-rose-50 hover:text-rose-700"
@@ -217,6 +364,68 @@ export default function MantenedoresPage() {
           )}
         </CardContent>
       </Card>
+
+
+      <ConfirmDialog
+        open={Boolean(transferTarget)}
+        title="Transferir inspeções"
+        description="Transfira as inspeções programadas deste mantenedor para um substituto."
+        onConfirm={handleTransferInspections}
+        onCancel={() => {
+          if (transferring) return;
+          setTransferTarget(null);
+        }}
+        busy={transferring}
+        footer={
+          <div className="space-y-5">
+            <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              {transferTarget ? (
+                <p>
+                  As programações pendentes de <strong>{transferTarget.original.nome}</strong> serão atribuídas ao substituto selecionado abaixo.
+                </p>
+              ) : null}
+            </div>
+            <label className="space-y-2 text-sm">
+              <span className="font-medium text-[var(--text)]">Substituto</span>
+              <Select
+                value={transferTarget?.substituteId ?? ""}
+                onChange={event => {
+                  const substituteId = event.target.value;
+                  setTransferTarget(current => current ? { ...current, substituteId } : current);
+                }}
+                disabled={transferring}
+              >
+                <option value="" disabled>Selecione um mantenedor ativo</option>
+                {activeMaintainers
+                  .filter(maintainer => maintainer.id !== transferTarget?.original.id)
+                  .map(maintainer => (
+                    <option key={maintainer.id} value={maintainer.id}>
+                      {maintainer.matricula ? `${maintainer.matricula} — ` : ""}{maintainer.nome}
+                    </option>
+                  ))}
+              </Select>
+            </label>
+            <div className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => setTransferTarget(null)}
+                disabled={transferring}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="button"
+                onClick={handleTransferInspections}
+                loading={transferring}
+                disabled={!transferTarget?.substituteId}
+              >
+                Transferir
+              </Button>
+            </div>
+          </div>
+        }
+      />
 
       <ConfirmDialog
         open={confirmOpen}

--- a/src/app/admin/mantenedores/page.tsx
+++ b/src/app/admin/mantenedores/page.tsx
@@ -26,6 +26,7 @@ type Maintainer = {
 type TransferTarget = {
   original: Maintainer;
   substituteId: string;
+  active: boolean;
 };
 
 function normalizeName(value: string | null | undefined) {
@@ -117,7 +118,7 @@ export default function MantenedoresPage() {
 
   function handleOpenTransfer(original: Maintainer) {
     const firstSubstitute = activeMaintainers.find(maintainer => maintainer.id !== original.id) ?? null;
-    setTransferTarget({ original, substituteId: firstSubstitute?.id ?? "" });
+    setTransferTarget({ original, substituteId: firstSubstitute?.id ?? "", active: true });
     setFeedback(null);
   }
 
@@ -126,6 +127,14 @@ export default function MantenedoresPage() {
     const substitute = data.find(maintainer => maintainer.id === transferTarget.substituteId);
     if (!substitute) {
       setFeedback({ type: "error", message: "Selecione um mantenedor substituto válido." });
+      return;
+    }
+    if (!transferTarget.active) {
+      setFeedback({
+        type: "success",
+        message: "Transferência desativada. Nenhuma inspeção programada foi alterada.",
+      });
+      setTransferTarget(null);
       return;
     }
 
@@ -385,6 +394,26 @@ export default function MantenedoresPage() {
                 </p>
               ) : null}
             </div>
+            <label className="flex items-center gap-3 rounded-2xl border border-[var(--border)] bg-[var(--surface)] px-4 py-3 text-sm text-[var(--text)]">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-[var(--primary)]"
+                checked={transferTarget?.active ?? false}
+                onChange={event => {
+                  const active = event.target.checked;
+                  setTransferTarget(current => current ? { ...current, active } : current);
+                }}
+                disabled={transferring}
+              />
+              <span>
+                Transferência ativa
+                {transferTarget?.substituteId ? (
+                  <strong className="ml-1">
+                    para {activeMaintainers.find(maintainer => maintainer.id === transferTarget.substituteId)?.nome ?? "substituto selecionado"}
+                  </strong>
+                ) : null}
+              </span>
+            </label>
             <label className="space-y-2 text-sm">
               <span className="font-medium text-[var(--text)]">Substituto</span>
               <Select

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -320,8 +320,9 @@ export default function AdminNonConformitiesPage() {
   const [items, setItems] = useState<NonConformityItem[]>([]);
   const [treatmentsByResponse, setTreatmentsByResponse] = useState<Record<string, ChecklistNonConformityTreatment[]>>({});
   const [machineFilter, setMachineFilter] = useState("");
+  const [machineSearch, setMachineSearch] = useState("");
   const [maintainerFilter, setMaintainerFilter] = useState("");
-  const [statusFilter, setStatusFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState("open");
   const [machineOptions, setMachineOptions] = useState<MachineOption[]>([]);
   const [maintainerOptions, setMaintainerOptions] = useState<MaintainerOption[]>([]);
   const [indexUrl, setIndexUrl] = useState<string | null>(null);
@@ -662,6 +663,42 @@ export default function AdminNonConformitiesPage() {
     return visibleItems;
   }, [items, statusFilter, dueDateFilter, forceVisibleIds]);
 
+  const machineDatalistOptions = useMemo(() => {
+    return machineOptions.map(machine => ({
+      id: machine.id,
+      label: buildMachineLabelFromOption(machine),
+      tag: machine.tag ?? "",
+    }));
+  }, [machineOptions]);
+
+  const applyMachineFilter = useCallback(() => {
+    const term = machineSearch.trim().toLowerCase();
+    if (!term) {
+      setMachineFilter("");
+      return;
+    }
+
+    const match = machineOptions.find(machine => {
+      const label = buildMachineLabelFromOption(machine).toLowerCase();
+      return (
+        machine.id.toLowerCase() === term ||
+        label === term ||
+        (machine.tag ?? "").toLowerCase() === term ||
+        label.includes(term)
+      );
+    });
+
+    setMachineFilter(match?.id ?? "");
+    if (match) {
+      setMachineSearch(buildMachineLabelFromOption(match));
+    }
+  }, [machineOptions, machineSearch]);
+
+  const clearMachineFilter = useCallback(() => {
+    setMachineSearch("");
+    setMachineFilter("");
+  }, []);
+
   const keepItemVisibleInCurrentFilter = useCallback((id: string) => {
     setForceVisibleIds(prev => new Set(prev).add(id));
   }, []);
@@ -913,14 +950,36 @@ export default function AdminNonConformitiesPage() {
         <CardContent className="grid gap-4 md:grid-cols-4">
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Máquina</span>
-            <Select value={machineFilter} onChange={event => setMachineFilter(event.target.value)}>
-              <option value="">Todas</option>
-              {machineOptions.map(option => (
-                <option key={option.id} value={option.id}>
-                  {buildMachineLabelFromOption(option)}
+            <div className="flex gap-2">
+              <Input
+                type="text"
+                value={machineSearch}
+                onChange={event => setMachineSearch(event.target.value)}
+                onKeyDown={event => {
+                  if (event.key === "Enter") {
+                    event.preventDefault();
+                    applyMachineFilter();
+                  }
+                }}
+                list="machine-filter-options"
+                placeholder="Digite nome, TAG ou ID"
+              />
+              <Button type="button" variant="secondary" onClick={applyMachineFilter} disabled={loading}>
+                Aplicar
+              </Button>
+              {machineFilter ? (
+                <Button type="button" variant="ghost" onClick={clearMachineFilter} disabled={loading}>
+                  Limpar
+                </Button>
+              ) : null}
+            </div>
+            <datalist id="machine-filter-options">
+              {machineDatalistOptions.map(option => (
+                <option key={option.id} value={option.label}>
+                  {option.tag ? `TAG ${option.tag}` : option.id}
                 </option>
               ))}
-            </Select>
+            </datalist>
           </label>
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Mantenedor</span>

--- a/src/app/admin/nc/page.tsx
+++ b/src/app/admin/nc/page.tsx
@@ -35,6 +35,13 @@ import type {
 import { resolveIssueLastActivityAt, sortByDueDateAsc, sortByLastActivityDesc } from "@/lib/non-conformity-priority";
 import { normalizeStoredImages } from "@/lib/storage/images";
 
+interface MaintainerOption {
+  id: string;
+  nome: string | null;
+  matricula: string | null;
+  ativo?: boolean;
+}
+
 interface MachineOption {
   id: string;
   nome: string;
@@ -263,6 +270,7 @@ function renderStatusBadge(status: NonConformityStatus) {
 const PAGE_SIZE = 20;
 const FIRESTORE_IN_QUERY_LIMIT = 30;
 const MACHINES_SESSION_CACHE_KEY = "admin-nc-machines-v1";
+const MAINTAINERS_SESSION_CACHE_KEY = "admin-nc-maintainers-v1";
 const TEMPLATES_SESSION_CACHE_KEY = "admin-nc-templates-v1";
 type IssueCursor = QueryDocumentSnapshot<DocumentData>;
 
@@ -283,6 +291,12 @@ function readSessionCache<T>(key: string): T[] | null {
 function writeSessionCache<T>(key: string, records: T[]) {
   if (typeof window === "undefined") return;
   window.sessionStorage.setItem(key, JSON.stringify(records));
+}
+
+function extractFirebaseIndexUrl(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  const match = message.match(/https:\/\/console\.firebase\.google\.com\/[^\s)]+/);
+  return match?.[0] ?? null;
 }
 
 function chunkArray<T>(items: T[], chunkSize: number): T[][] {
@@ -307,7 +321,10 @@ export default function AdminNonConformitiesPage() {
   const [treatmentsByResponse, setTreatmentsByResponse] = useState<Record<string, ChecklistNonConformityTreatment[]>>({});
   const [machineFilter, setMachineFilter] = useState("");
   const [maintainerFilter, setMaintainerFilter] = useState("");
-  const [statusFilter, setStatusFilter] = useState("open");
+  const [statusFilter, setStatusFilter] = useState("all");
+  const [machineOptions, setMachineOptions] = useState<MachineOption[]>([]);
+  const [maintainerOptions, setMaintainerOptions] = useState<MaintainerOption[]>([]);
+  const [indexUrl, setIndexUrl] = useState<string | null>(null);
   const [dueDateFilter, setDueDateFilter] = useState("default");
   const [savingId, setSavingId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<Record<string, FeedbackState>>({});
@@ -320,7 +337,6 @@ export default function AdminNonConformitiesPage() {
   const [hasMoreItems, setHasMoreItems] = useState(false);
   const lastIssueCursorRef = useRef<IssueCursor | null>(null);
 
-  const shouldRefreshOnFilterChange = Boolean(maintainerFilter || statusFilter !== "open" || dueDateFilter !== "default");
 
   useEffect(() => {
     setSelectedIds(prev => prev.filter(id => items.some(item => item.id === id)));
@@ -349,13 +365,20 @@ export default function AdminNonConformitiesPage() {
       }
 
       const cachedMachines = readSessionCache<MachineOption>(MACHINES_SESSION_CACHE_KEY);
+      const cachedMaintainers = readSessionCache<MaintainerOption>(MAINTAINERS_SESSION_CACHE_KEY);
       const cachedTemplates = readSessionCache<TemplateCacheRecord>(TEMPLATES_SESSION_CACHE_KEY);
-      const issueConstraints = cursor && shouldAppend
-        ? [where("status", "in", ["aberta", "concluida", "resolvida"]), orderBy("updatedAt", "desc"), startAfter(cursor), limit(PAGE_SIZE)]
-        : [where("status", "in", ["aberta", "concluida", "resolvida"]), orderBy("updatedAt", "desc"), limit(PAGE_SIZE)];
+      const issueConstraints = [];
+      if (machineFilter) issueConstraints.push(where("machineId", "==", machineFilter));
+      if (maintainerFilter) issueConstraints.push(where("maintainerResolution.resolvedByMatricula", "==", maintainerFilter));
+      if (statusFilter === "open") issueConstraints.push(where("status", "==", "aberta"));
+      if (statusFilter === "resolved") issueConstraints.push(where("status", "in", ["concluida", "resolvida"]));
+      issueConstraints.push(orderBy("updatedAt", "desc"));
+      if (cursor && shouldAppend) issueConstraints.push(startAfter(cursor));
+      issueConstraints.push(limit(PAGE_SIZE));
 
-      const [machinesSnap, templatesSnap, issuesSnap] = await Promise.all([
+      const [machinesSnap, maintainersSnap, templatesSnap, issuesSnap] = await Promise.all([
         cachedMachines ? Promise.resolve(null) : getDocs(collection(firebaseDb, "machines")),
+        cachedMaintainers ? Promise.resolve(null) : getDocs(collection(firebaseDb, "mantenedores")),
         cachedTemplates ? Promise.resolve(null) : getDocs(collection(firebaseDb, "templates")),
         getDocs(query(collection(firebaseDb, "issues"), ...issueConstraints)),
       ]);
@@ -371,6 +394,13 @@ export default function AdminNonConformitiesPage() {
         } satisfies MachineOption;
       });
       if (!cachedMachines) writeSessionCache(MACHINES_SESSION_CACHE_KEY, machineOptions);
+      setMachineOptions(machineOptions.sort((a, b) => buildMachineLabelFromOption(a).localeCompare(buildMachineLabelFromOption(b), "pt-BR")));
+      const maintainerRecords: MaintainerOption[] = cachedMaintainers ?? maintainersSnap!.docs.map(docSnap => {
+        const data = docSnap.data() ?? {};
+        return { id: docSnap.id, nome: typeof data.nome === "string" ? data.nome : null, matricula: typeof data.matricula === "string" ? data.matricula.toUpperCase() : null, ativo: data.ativo !== false };
+      });
+      if (!cachedMaintainers) writeSessionCache(MAINTAINERS_SESSION_CACHE_KEY, maintainerRecords);
+      setMaintainerOptions(maintainerRecords.sort((a, b) => (a.nome ?? a.matricula ?? a.id).localeCompare(b.nome ?? b.matricula ?? b.id, "pt-BR")));
       const machinesById = new Map(machineOptions.map(machine => [machine.id, machine]));
 
       const templateRecords: TemplateCacheRecord[] = cachedTemplates ?? templatesSnap!.docs.map(docSnap => {
@@ -601,8 +631,10 @@ export default function AdminNonConformitiesPage() {
       lastIssueCursorRef.current = issuesSnap.docs.at(-1) ?? null;
       setHasMoreItems(issuesSnap.docs.length === PAGE_SIZE);
     } catch (err: unknown) {
+      const indexLink = extractFirebaseIndexUrl(err);
+      if (indexLink) setIndexUrl(indexLink);
       const message = err instanceof Error && err.message ? err.message : "Erro ao carregar dados";
-      setError(message);
+      setError(indexLink ? "O Firestore exige um índice composto para esta consulta." : message);
     } finally {
       if (shouldAppend) {
         setLoadingMore(false);
@@ -610,84 +642,25 @@ export default function AdminNonConformitiesPage() {
         setLoading(false);
       }
     }
-  }, []);
+  }, [machineFilter, maintainerFilter, statusFilter]);
 
-  useEffect(() => {
-    loadData();
-  }, [loadData]);
 
   useEffect(() => {
     setForceVisibleIds(new Set());
-  }, [dueDateFilter, machineFilter, maintainerFilter, statusFilter]);
-
-  useEffect(() => {
-    if (shouldRefreshOnFilterChange) {
-      loadData();
-    }
-  }, [dueDateFilter, loadData, maintainerFilter, shouldRefreshOnFilterChange, statusFilter]);
-
-  const machineOptionsForFilter = useMemo(() => {
-    return Array.from(new Set(items.map(item => item.machineLabel.trim()).filter(Boolean))).sort((a, b) =>
-      a.localeCompare(b, "pt-BR")
-    );
-  }, [items]);
-
-  const maintainerOptionsForFilter = useMemo(() => {
-    const maintainers = new Map<string, string>();
-    items.forEach(item => {
-      const nome = item.operatorNome?.trim();
-      if (!nome) return;
-      const matricula = item.operatorMatricula?.trim();
-      const label = matricula ? `${nome} (mat. ${matricula})` : nome;
-      maintainers.set(nome, label);
-    });
-    return Array.from(maintainers.entries())
-      .sort((a, b) => a[1].localeCompare(b[1], "pt-BR"))
-      .map(([value, label]) => ({ value, label }));
-  }, [items]);
+    loadData("reset");
+  }, [dueDateFilter, machineFilter, maintainerFilter, statusFilter, loadData]);
 
   const filteredItems = useMemo(() => {
-    const machineSearch = machineFilter.trim().toLowerCase();
     const visibleItems = items.filter(item => {
-      if (forceVisibleIds.has(item.id)) {
-        return true;
-      }
-      if (machineSearch) {
-        const machineLabel = item.machineLabel.toLowerCase();
-        const machineTag = (item.machineTag ?? "").toLowerCase();
-        const machineId = (item.machineId ?? "").toLowerCase();
-        if (
-          !machineLabel.includes(machineSearch) &&
-          !machineTag.includes(machineSearch) &&
-          !machineId.includes(machineSearch)
-        ) {
-          return false;
-        }
-      }
-      if (maintainerFilter && item.operatorNome !== maintainerFilter) {
-        return false;
-      }
-      if (statusFilter === "planned") {
-        return Boolean(item.summary.trim() || item.responsible.trim() || item.dueDate);
-      }
-      if (statusFilter === "unplanned") {
-        return !Boolean(item.summary.trim() || item.responsible.trim() || item.dueDate);
-      }
-      if (statusFilter === "all") {
-        return true;
-      }
-      if (statusFilter === "maintainer_resolved") {
-        return item.maintainerResolution != null;
-      }
-      return item.status === statusFilter;
+      if (forceVisibleIds.has(item.id)) return true;
+      if (statusFilter === "planned") return Boolean(item.summary.trim() || item.responsible.trim() || item.dueDate);
+      if (statusFilter === "unplanned") return !Boolean(item.summary.trim() || item.responsible.trim() || item.dueDate);
+      if (statusFilter === "maintainer_resolved") return item.maintainerResolution != null;
+      return true;
     });
-
-    if (dueDateFilter === "oldest_first") {
-      return sortByDueDateAsc(visibleItems);
-    }
-
+    if (dueDateFilter === "oldest_first") return sortByDueDateAsc(visibleItems);
     return visibleItems;
-  }, [items, machineFilter, maintainerFilter, statusFilter, dueDateFilter, forceVisibleIds]);
+  }, [items, statusFilter, dueDateFilter, forceVisibleIds]);
 
   const keepItemVisibleInCurrentFilter = useCallback((id: string) => {
     setForceVisibleIds(prev => new Set(prev).add(id));
@@ -914,7 +887,8 @@ export default function AdminNonConformitiesPage() {
           </Button>
         </header>
         <div className="rounded-lg border border-[var(--danger)] bg-[color-mix(in_oklab,var(--danger),#fff_80%)] px-4 py-3 text-[var(--danger)]">
-          {error}
+          <p>{error}</p>
+          {indexUrl ? <a className="underline" href={indexUrl} target="_blank" rel="noreferrer">Criar índice composto no Firebase</a> : null}
         </div>
       </div>
     );
@@ -939,26 +913,22 @@ export default function AdminNonConformitiesPage() {
         <CardContent className="grid gap-4 md:grid-cols-4">
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Máquina</span>
-            <Input
-              type="text"
-              value={machineFilter}
-              onChange={event => setMachineFilter(event.target.value)}
-              list="machine-filter-options"
-              placeholder="Digite nome, tag ou ID"
-            />
-            <datalist id="machine-filter-options">
-              {machineOptionsForFilter.map(option => (
-                <option key={option} value={option} />
+            <Select value={machineFilter} onChange={event => setMachineFilter(event.target.value)}>
+              <option value="">Todas</option>
+              {machineOptions.map(option => (
+                <option key={option.id} value={option.id}>
+                  {buildMachineLabelFromOption(option)}
+                </option>
               ))}
-            </datalist>
+            </Select>
           </label>
           <label className="space-y-1 text-sm">
             <span className="text-[var(--muted)]">Mantenedor</span>
             <Select value={maintainerFilter} onChange={event => setMaintainerFilter(event.target.value)}>
               <option value="">Todos</option>
-              {maintainerOptionsForFilter.map(option => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
+              {maintainerOptions.map(option => (
+                <option key={option.id} value={option.matricula ?? option.id}>
+                  {option.matricula ? `${option.matricula} — ` : ""}{option.nome ?? option.id}
                 </option>
               ))}
             </Select>

--- a/src/app/api/inspecoes/[id]/return/route.ts
+++ b/src/app/api/inspecoes/[id]/return/route.ts
@@ -1,0 +1,149 @@
+import { FieldValue } from "firebase-admin/firestore";
+import { NextRequest, NextResponse } from "next/server";
+import { adminDb } from "@/lib/firebase-admin";
+import { requireAdminFromRequest } from "@/lib/guards";
+import { normalizeStoredImages } from "@/lib/storage/images";
+import type { ChecklistAnswer } from "@/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = { params: Promise<Record<string, string | string[] | undefined>> };
+
+type DraftFoto = { dataUrl: string; name: string | null };
+
+function resolveId(params: Record<string, string | string[] | undefined>) {
+  const value = params.id;
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+function coerceString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function normalizeResult(value: unknown): "C" | "NC" | "NA" | "" {
+  const raw = String(value ?? "").trim().toLowerCase();
+  if (raw === "nc") return "NC";
+  if (raw === "na") return "NA";
+  if (raw === "c") return "C";
+  return "";
+}
+
+function normalizeDraftFotos(value: unknown): DraftFoto[] {
+  return normalizeStoredImages(value)
+    .map(image => ({ dataUrl: image.url, name: image.key ?? null }))
+    .filter(photo => photo.dataUrl.trim().length > 0)
+    .slice(0, 3);
+}
+
+function buildDraftItems(data: Record<string, unknown>) {
+  const answers = Array.isArray(data.answers) ? (data.answers as ChecklistAnswer[]) : [];
+  if (answers.length > 0) {
+    return Object.fromEntries(
+      answers
+        .filter(answer => answer?.questionId)
+        .map(answer => [
+          answer.questionId,
+          {
+            resultado: normalizeResult(answer.response),
+            observacao: coerceString(answer.observation),
+            osNumero: coerceString(answer.itemOsNumero)?.toUpperCase() ?? null,
+            fotos: normalizeDraftFotos(answer.photoUrls),
+          },
+        ])
+    );
+  }
+
+  const itens = Array.isArray(data.itens) ? (data.itens as Array<Record<string, unknown>>) : [];
+  return Object.fromEntries(
+    itens
+      .filter(item => coerceString(item.templateItemId))
+      .map(item => [
+        coerceString(item.templateItemId)!,
+        {
+          resultado: normalizeResult(item.resultado ?? item.response),
+          observacao: coerceString(item.observacaoItem ?? item.observacao),
+          osNumero: coerceString(item.osNumeroItem ?? item.osNumero)?.toUpperCase() ?? null,
+          fotos: normalizeDraftFotos(item.fotos ?? item.photoUrls),
+        },
+      ])
+  );
+}
+
+export async function PATCH(req: NextRequest, context: RouteContext) {
+  const authorized = await requireAdminFromRequest(req);
+  if (!authorized) {
+    return NextResponse.json({ error: "UNAUTHENTICATED" }, { status: 401 });
+  }
+
+  const params = (await context.params) ?? {};
+  const id = resolveId(params);
+  if (!id) {
+    return NextResponse.json({ error: "INSPECTION_ID_REQUIRED" }, { status: 400 });
+  }
+
+  const inspectionRef = adminDb.collection("inspecoes").doc(id);
+  const inspectionSnap = await inspectionRef.get();
+  if (!inspectionSnap.exists) {
+    return NextResponse.json({ error: "INSPECTION_NOT_FOUND" }, { status: 404 });
+  }
+
+  const data = inspectionSnap.data() ?? {};
+  const maintainer = (data.maintainer ?? {}) as Record<string, unknown>;
+  const machine = (data.machine ?? {}) as Record<string, unknown>;
+  const template = (data.template ?? {}) as Record<string, unknown>;
+  const maintainerId = coerceString(maintainer.maintId) ?? coerceString(maintainer.id);
+  const machineId = coerceString(machine.machineId) ?? coerceString(machine.id);
+
+  if (!maintainerId || !machineId) {
+    return NextResponse.json({ error: "INSPECTION_MAINTAINER_OR_MACHINE_MISSING" }, { status: 422 });
+  }
+
+  const itens = buildDraftItems(data);
+  const totalItens = Object.keys(itens).length;
+  const answeredItens = Object.values(itens).filter(item => item.resultado === "C" || item.resultado === "NC" || item.resultado === "NA").length;
+  const nowIso = new Date().toISOString();
+  const draftId = `${maintainerId}__${machineId}`;
+
+  const batch = adminDb.batch();
+  batch.set(
+    adminDb.collection("inspectionDrafts").doc(draftId),
+    {
+      returnedInspectionId: id,
+      returnedByAdmin: true,
+      maintainerId,
+      machineId,
+      machineTag: coerceString(machine.tag),
+      machineNome: coerceString(machine.nome),
+      machineSetor: coerceString(machine.setor),
+      machineUnidade: coerceString(machine.unidade),
+      templateId: coerceString(template.id) ?? coerceString(machine.templateId),
+      templateNome: coerceString(template.nome),
+      osNumero: coerceString(data.osNumero)?.toUpperCase() ?? null,
+      observacoes: coerceString(data.observacoes),
+      assinaturaDataUrl: coerceString(data.assinaturaDataUrl),
+      itens,
+      totalItens,
+      answeredItens,
+      progressPercent: totalItens > 0 ? Math.round((answeredItens / totalItens) * 100) : 0,
+      createdAt: coerceString(data.createdAt) ?? nowIso,
+      updatedAt: nowIso,
+    },
+    { merge: false }
+  );
+  batch.update(inspectionRef, {
+    status: "rascunho",
+    returnedToMaintainer: true,
+    returnedAt: nowIso,
+    updatedAt: nowIso,
+    finalizadaEm: FieldValue.delete(),
+    finalizadaEmTimestamp: FieldValue.delete(),
+    pcmSign: FieldValue.delete(),
+    submittedAt: FieldValue.delete(),
+    signatures: FieldValue.delete(),
+  });
+  await batch.commit();
+
+  return NextResponse.json({ ok: true, draftId });
+}


### PR DESCRIPTION
### Motivation
- Allow admins to filter inspections by mantenedor and act on individual inspections (return to maintainer) directly from the UI.
- Provide a way to transfer scheduled inspections when a maintainer is absent and create a rascunho when returning an inspection.
- Improve performance by caching machines/templates/maintainers in sessionStorage and give actionable error guidance when Firestore requires a composite index.
- Reorganize signature modal UI to keep evaluated items visible with the signature section.

### Description
- Added maintainer loading and session cache helpers (`readSessionCache`/`writeSessionCache`) and integrated maintainer selection into `AdminInspectionsPage` with server-side `loadMaintainers` and a per-maintainer Firestore query; introduced UI for selecting/clearing a single maintainer and updated list behaviour accordingly.
- Implemented Firestore query error extraction (`extractFirebaseIndexUrl`) and surface the composite index URL in error UI for both inspections and non-conformities pages.
- Added a return flow: a confirm dialog and button in the inspections list that calls a new API route `PATCH /api/inspecoes/[id]/return`, which writes an `inspectionDrafts` document and updates the original inspection to `status: 'rascunho'` removing PCM signature metadata.
- Implemented transfer tooling in `MantenedoresPage` to reassign pending scheduled inspections (`programacoes_inspecao`) from one maintainer to another using batched updates, plus UI to pick a substitute and run the transfer; includes helpers `normalizeName`, `chunkArray` and safe batching logic.
- Improved the non-conformities admin page to fetch and cache maintainers, expose maintainer and machine selects, broaden status filtering, and apply the same index hinting and session cache approach used elsewhere.
- Small UI/UX and structural tweaks: moved the "Itens avaliados" block inside the signature modal to improve layout and added a `ConfirmDialog` instance for the return action.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a590931831883298b799edd05722f4f)